### PR TITLE
sokol-shdc: add SOKOL_SHDC_DECL define (#12)

### DIFF
--- a/src/shdc/sokol.cc
+++ b/src/shdc/sokol.cc
@@ -488,6 +488,7 @@ errmsg_t sokol_t::gen(const args_t& args, const input_t& inp,
     errmsg_t err;
     bool comment_header_written = false;
     bool common_decls_written = false;
+    bool decl_guard_written = false;
     for (int i = 0; i < slang_t::NUM; i++) {
         slang_t::type_t slang = (slang_t::type_t) i;
         if (args.slang & slang_t::bit(slang)) {
@@ -504,6 +505,10 @@ errmsg_t sokol_t::gen(const args_t& args, const input_t& inp,
                 write_vertex_attrs(inp, spirvcross[i]);
                 write_images_bind_slots(inp, spirvcross[i]);
                 write_uniform_blocks(inp, spirvcross[i], slang);
+            }
+            if (!decl_guard_written) {
+                decl_guard_written = true;
+                L("#if !defined(SOKOL_SHDC_DECL)\n");
             }
             if (!args.no_ifdef) {
                 L("#if defined({})\n", sokol_define(slang));
@@ -536,6 +541,10 @@ errmsg_t sokol_t::gen(const args_t& args, const input_t& inp,
         }
         L("    return 0; /* can't happen */\n");
         L("}}\n");
+    }
+
+    if (decl_guard_written) {
+        L("#endif /* SOKOL_SHDC_DECL */\n");
     }
 
     // write result into output file


### PR DESCRIPTION
If user code defines SOKOL_SHDC_DECL, only declarations (attrs, bind slots, uniform blocks) are included.

Additional observation: it may be possible to move the `SOKOL_GFX_INCLUDED` check down, into this guarded section, as a minor optimization - but I'm not sure if there are use cases where `sokol_gfx.h` is needed for the type definitions.