### PR TITLE
support for multiple shaders in same .glsl file for bare format

### DIFF
--- a/src/shdc/output.cc
+++ b/src/shdc/output.cc
@@ -29,5 +29,5 @@ errmsg_t output_t::check_errors(const input_t& inp,
     // all ok
     return errmsg_t();
 }
-    
+
 }

--- a/src/shdc/shdc.h
+++ b/src/shdc/shdc.h
@@ -424,6 +424,15 @@ struct bare_t {
 };
 
 /* utility functions for generators */
+inline std::string mod_prefix(const input_t& inp) {
+    if (inp.module.empty()) {
+        return "";
+    }
+    else {
+        return fmt::format("{}_", inp.module);
+    }
+}
+
 struct output_t {
     static errmsg_t check_errors(const input_t& inp, const spirvcross_t& spirvcross, slang_t::type_t slang);
 };

--- a/src/shdc/sokol.cc
+++ b/src/shdc/sokol.cc
@@ -42,15 +42,6 @@ static int roundup(int val, int round_to) {
     return (val + (round_to - 1)) & ~(round_to - 1);
 }
 
-static std::string mod_prefix(const input_t& inp) {
-    if (inp.module.empty()) {
-        return "";
-    }
-    else {
-        return fmt::format("{}_", inp.module);
-    }
-}
-
 static const char* img_type_to_sokol_type_str(image_t::type_t type) {
     switch (type) {
         case image_t::IMAGE_2D: return "SG_IMAGETYPE_2D";


### PR DESCRIPTION
This breaks the existing output file format, but I couldn't think of a way to work around that.

With these changes the output filename will be: 
arg.output + mod_name + program_name + {_vs|_fs} + {ending}

_vs / _fs seemed to match existing naming in sokol better than .vert / .frag, but if you prefer to keep .vert/.frag I wouldn't mind changing it.

