### PR TITLE
Allow writing standards-compliant-ish glsl by allowing tags to be prefixed by #pragma sokol

### DIFF
--- a/docs/sokol-shdc.md
+++ b/docs/sokol-shdc.md
@@ -58,6 +58,11 @@ void main() {
 
 @program triangle vs fs
 ```
+Note: For compatibility with other tools which parse GLSL, `#pragma sokol` may be used to prefix the tags. For example, the final line above could have also been written as:
+
+```glsl
+#pragma sokol @program triangle vs fs
+```
 
 The generated C header contains:
 


### PR DESCRIPTION
Fixes #24. I didn't put this behind a flag since I don't see the point in that, but am willing to if you'd prefer.