### PR TITLE
Emit reflection information in "bare" output mode.

### DIFF
--- a/src/shdc/main.cc
+++ b/src/shdc/main.cc
@@ -60,7 +60,7 @@ int main(int argc, const char** argv) {
         if (args.slang & slang_t::bit(slang)) {
             spirvcross[i] = spirvcross_t::translate(inp, spirv[i], slang);
             if (args.debug_dump) {
-                spirvcross[i].dump_debug(args.error_format, slang);
+                spirvcross[i].dump_debug(stderr, args.error_format, slang);
             }
             if (spirvcross[i].error.valid) {
                 spirvcross[i].error.print(args.error_format);

--- a/src/shdc/shdc.h
+++ b/src/shdc/shdc.h
@@ -463,7 +463,8 @@ struct spirvcross_t {
 
     static spirvcross_t translate(const input_t& inp, const spirv_t& spirv, slang_t::type_t slang);
     int find_source_by_snippet_index(int snippet_index) const;
-    void dump_debug(errmsg_t::msg_format_t err_fmt, slang_t::type_t slang) const;
+    void write_reflection_info(FILE* stream, const spirvcross_source_t& source, const std::string& indent) const;
+    void dump_debug(FILE* stream, errmsg_t::msg_format_t err_fmt, slang_t::type_t slang) const;
 };
 
 /* HLSL/Metal to bytecode compiler wrapper */


### PR DESCRIPTION
For using sokol and sokol-shdc from languages other than C, or in a runtime context, it's useful to be able to be able to populate your own `sg_shader_desc` at runtime, instead of having to integrate it into a build process.

This pull request repurposes the `spirvcross` "`dump`" function to emit each shader's reflection information into an easily-parsable shader file next to the output file, but with a `.meta` extension.

For example, one `.meta` output file looks like:

```
stage: FS
entry: main
inputs:
outputs:
  frag_color: slot=0, sem_name=TEXCOORD, sem_index=0
uniform block: fs_params, slot: 0, size: 16
  member: mycolor, type: FLOAT4, array_count: 1, offset: 0
```  