### PR TITLE
fix `build.zig`

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -11,7 +11,8 @@ pub fn build(b: *bld.Builder) void {
         "sokol.cc",
         "sokolzig.cc",
         "spirv.cc",
-        "spirvcross.cc"
+        "spirvcross.cc",
+        "util.cc"
     };
     const incl_dirs = [_][] const u8 {
         "ext/fmt/include",

--- a/build.zig
+++ b/build.zig
@@ -8,7 +8,6 @@ pub fn build(b: *bld.Builder) void {
         "bytecode.cc",
         "input.cc",
         "main.cc",
-        "output.cc",
         "sokol.cc",
         "sokolzig.cc",
         "spirv.cc",


### PR DESCRIPTION
It seems the `build.zig` file is outdated: `output.cc` doesn't exist anymore, and `util.cc` should be included.