### PR TITLE
Fix consteval errors when compiling as C++20

### DIFF
--- a/src/shdc/args.cc
+++ b/src/shdc/args.cc
@@ -91,7 +91,7 @@ static void print_help_string(getopt_context_t& ctx) {
         "  - bare:          raw output of SPIRV-Cross compiler, in text or binary format\n\n"
         "Options:\n\n");
     char buf[2048];
-    fmt::print(stderr, getopt_create_help_string(&ctx, buf, sizeof(buf)));
+    fmt::print(stderr, "{}", getopt_create_help_string(&ctx, buf, sizeof(buf)));
 }
 
 /* parse string of format 'hlsl4|glsl100|...' args.slang bitmask */

--- a/src/shdc/spirv.cc
+++ b/src/shdc/spirv.cc
@@ -215,7 +215,7 @@ static bool compile(EShLanguage stage, slang_t::type_t slang, const std::string&
     if (!spirv_log.empty()) {
         // FIXME: need to parse string for errors and translate to errmsg_t objects?
         // haven't seen a case yet where this generates log messages
-        fmt::print(spirv_log);
+        fmt::print("{}", spirv_log);
     }
     // run optimizer passes
     spirv_optimize(slang, out_spirv.blobs.back().bytecode);


### PR DESCRIPTION
`fmt::print()` expects the format argument to be consteval.