### PR TITLE
Fix spelling of keyword

### DIFF
--- a/docs/sokol-shdc.md
+++ b/docs/sokol-shdc.md
@@ -637,7 +637,7 @@ arguments:
     - MSL: In vertex shaders, rewrite [-w, w] depth (GL style) to [0, w] depth.
 - **flip_vert_y**: Inverts gl_Position.y or equivalent. (all shader languages)
 
-Currently, ```@glsl_option```, ```@hlsl_option``` and ```@msl_option``` are only
+Currently, ```@glsl_options```, ```@hlsl_options``` and ```@msl_options``` are only
 allowed inside ```@vs, @end``` blocks.
 
 Example from the [mrt-sapp sample](https://floooh.github.io/sokol-html5/wasm/mrt-sapp.html),


### PR DESCRIPTION
Looks like the actual keyword used has the 's' at the end, when I use the singular form I get a sokol-shdc error like:

    ./../cppsrc/opengl/programs/shaders/pole_cap_program.sokol:3:0: error: unknown meta tag: @msl_option
