### PR TITLE
Generate yaml info for bare format

### DIFF
--- a/src/shdc/bare.cc
+++ b/src/shdc/bare.cc
@@ -10,6 +10,14 @@ namespace shdc {
 
 using namespace util;
 
+static std::string file_content;
+
+#if defined(_MSC_VER)
+#define L(str, ...) file_content.append(fmt::format(str, __VA_ARGS__))
+#else
+#define L(str, ...) file_content.append(fmt::format(str, ##__VA_ARGS__))
+#endif
+
 static const char* slang_file_extension(slang_t::type_t c, bool binary) {
     switch (c) {
         case slang_t::GLSL330:
@@ -56,12 +64,83 @@ static errmsg_t write_stage(const std::string& file_path,
     return errmsg_t();
 }
 
+static void write_attribute(const attr_t& att)
+{
+    L("            -\n");
+    L("              slot: {}\n", att.slot);
+    L("              name: {}\n", att.name);
+    L("              sem_name: {}\n", att.sem_name);
+    L("              sem_index: {}\n", att.sem_index);
+}
+
+static void write_uniform(const uniform_block_t& uniform_block)
+{
+    L("            -\n");
+    L("              slot: {}\n", uniform_block.slot);
+    L("              size: {}\n", uniform_block.size);
+    L("              struct_name: {}\n", uniform_block.struct_name);
+    L("              uniforms:\n");
+    for (const auto& uniform: uniform_block.uniforms)
+    {
+        L("                -\n");
+        L("                  name: {}\n", uniform.name);
+        L("                  type: {}\n", uniform_t::type_to_str(uniform.type));
+        L("                  array_count: {}\n", uniform.array_count);
+        L("                  offset: {}\n", uniform.offset);
+    }
+}
+
+static void write_image(const image_t& image)
+{
+    L("            -\n");
+    L("              slot: {}\n", image.slot);
+    L("              name: {}\n", image.name);
+    L("              type: {}\n", image_t::type_to_str(image.type));
+    L("              base_type: {}\n", image_t::basetype_to_str(image.base_type));
+}
+
+static void write_source_reflection(const spirvcross_source_t* src)
+{
+    L("          entry_point: {}\n", src->refl.entry_point);
+    L("          inputs:\n");
+    for (const auto& input : src->refl.inputs)
+    {
+        if (input.slot == -1) break;
+        write_attribute(input);
+    }
+    L("          outputs:\n");
+    for (const auto& output : src->refl.outputs)
+    {
+        if (output.slot == -1) break;
+        write_attribute(output);
+    }
+    if (src->refl.uniform_blocks.size() > 0)
+    {
+        L("          uniform_blocks:\n");
+        for (const auto& uniform : src->refl.uniform_blocks)
+        {
+            if (uniform.slot == -1) break;
+            write_uniform(uniform);
+        }
+    }
+    if (src->refl.images.size() > 0)
+    {
+        L("          images:\n");
+        for (const auto& image : src->refl.images)
+        {
+            if (image.slot == -1) break;
+            write_image(image);
+        }
+    }
+}
+
 static errmsg_t write_shader_sources_and_blobs(const args_t& args,
                                                const input_t& inp,
                                                const spirvcross_t& spirvcross,
                                                const bytecode_t& bytecode,
                                                slang_t::type_t slang)
 {
+    L("    programs:\n");
     for (const auto& item: inp.programs) {
         const program_t& prog = item.second;
         const spirvcross_source_t* vs_src = find_spirvcross_source_by_shader_name(prog.vs_name, inp, spirvcross);
@@ -80,6 +159,15 @@ static errmsg_t write_shader_sources_and_blobs(const args_t& args,
         if (err.valid) {
             return err;
         }
+
+        L("      -\n");
+        L("        name: {}\n", prog.name);
+        L("        vs:\n");
+        L("          path: {}\n", file_path_vs);
+        write_source_reflection(vs_src);
+        L("        fs:\n");
+        L("          path: {}\n", file_path_fs);
+        write_source_reflection(fs_src);
     }
 
     return errmsg_t();
@@ -89,6 +177,12 @@ errmsg_t bare_t::gen(const args_t& args, const input_t& inp,
                      const std::array<spirvcross_t,slang_t::NUM>& spirvcross,
                      const std::array<bytecode_t,slang_t::NUM>& bytecode)
 {
+    // first write everything into a string, and only when no errors occur,
+    // dump this into a file (so we don't have half-written files lying around)
+    file_content.clear();
+
+    L("shaders:\n");
+
     for (int i = 0; i < slang_t::NUM; i++) {
         slang_t::type_t slang = (slang_t::type_t) i;
         if (args.slang & slang_t::bit(slang)) {
@@ -96,12 +190,22 @@ errmsg_t bare_t::gen(const args_t& args, const input_t& inp,
             if (err.valid) {
                 return err;
             }
+            L("  -\n");
+            L("    slang: {}\n", slang_t::to_str(slang));
             err = write_shader_sources_and_blobs(args, inp, spirvcross[i], bytecode[i], slang);
             if (err.valid) {
                 return err;
             }
         }
     }
+
+    // write result into output file
+    FILE* f = fopen(fmt::format("{}{}.yaml", args.output, mod_prefix2(inp)).c_str(), "w");
+    if (!f) {
+        return errmsg_t::error(inp.base_path, 0, fmt::format("failed to open output file '{}'", args.output));
+    }
+    fwrite(file_content.c_str(), file_content.length(), 1, f);
+    fclose(f);
 
     return errmsg_t();
 }

--- a/src/shdc/shdc.h
+++ b/src/shdc/shdc.h
@@ -580,6 +580,7 @@ namespace util {
     int uniform_size(uniform_t::type_t type, int array_size);
     int roundup(int val, int round_to);
     std::string mod_prefix(const input_t& inp);
+    std::string mod_prefix2(const input_t& inp);
     const uniform_block_t* find_uniform_block(const spirvcross_refl_t& refl, int slot);
     const image_t* find_image(const spirvcross_refl_t& refl, int slot);
     const spirvcross_source_t* find_spirvcross_source_by_shader_name(const std::string& shader_name, const input_t& inp, const spirvcross_t& spirvcross);

--- a/src/shdc/util.cc
+++ b/src/shdc/util.cc
@@ -89,6 +89,16 @@ std::string mod_prefix(const input_t& inp) {
     }
 }
 
+std::string mod_prefix2(const input_t& inp) {
+    if (inp.module.empty()) {
+        return "";
+    }
+    else {
+        return fmt::format("_{}", inp.module);
+    }
+}
+
+
 const uniform_block_t* find_uniform_block(const spirvcross_refl_t& refl, int slot) {
     for (const uniform_block_t& ub: refl.uniform_blocks) {
         if (ub.slot == slot) {


### PR DESCRIPTION
Generate yaml file info for bare format shaders. 
It can be useful if somebody wants to use sokol_shc on the fly or for using with another libraries other than sokol.

I attached an output sample for you to take a view.
[test_slm.txt](https://github.com/floooh/sokol-tools/files/9062155/test_slm.txt)

Please let me know if you need more info or any change requests.