### PR TITLE
There may be a typo here, there is only backendGles3 in the nim binding

### DIFF
--- a/src/shdc/sokolnim.cc
+++ b/src/shdc/sokolnim.cc
@@ -72,8 +72,8 @@ static const char* img_basetype_to_sokol_samplertype_str(image_t::basetype_t bas
 static const char* sokol_backend(slang_t::type_t slang) {
     switch (slang) {
         case slang_t::GLSL330:      return "backendGlcore33";
-        case slang_t::GLSL100:      return "backend.Gles2";
-        case slang_t::GLSL300ES:    return "backendGles2";
+        case slang_t::GLSL100:      return "backendGles3";
+        case slang_t::GLSL300ES:    return "backendGles3";
         case slang_t::HLSL4:        return "backendD3d11";
         case slang_t::HLSL5:        return "backendD3d11";
         case slang_t::METAL_MACOS:  return "backendMetalMacos";


### PR DESCRIPTION
[nim binding](https://github.com/floooh/sokol-nim/blob/56bb1389fd265cebe72f04257446d78a356656ff/src/sokol/gfx.nim#L45C1-L54C18)

```nim
type
  Backend* {.size:sizeof(int32).} = enum
    backendGlcore33,
    backendGles3,   # here
    backendD3d11,
    backendMetalIos,
    backendMetalMacos,
    backendMetalSimulator,
    backendWgpu,
    backendDummy,
```
