### PR TITLE
Fix/issue-109: Different approach to reflection parsing for HLSL, MSL, WGSL.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ CHANGELOG
 Fix a reflection parsing regression that was introduced in the last
 update (see: https://github.com/floooh/sokol-tools/issues/109).
 
-This avoids having to deal with 'dummy samplers' when parsing reflection
+The fix avoids having to deal with 'dummy samplers' when parsing reflection
 information for HLSL, WGSL and MSL by using a common GLSL output
 for parsing reflection data instead of using the HLSL, WGSL and MSL
 output.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,16 @@
 CHANGELOG
 =========
 
+#### **29-Oct-2023**
+
+Fix a reflection parsing regression that was introduced in the last
+update (see: https://github.com/floooh/sokol-tools/issues/109).
+
+This avoids having to deal with 'dummy samplers' when parsing reflection
+information for HLSL, WGSL and MSL by using a common GLSL output
+for parsing reflection data instead of using the HLSL, WGSL and MSL
+output.
+
 #### **18-Oct-2023**
 
 > NOTE: this update is required for WebGPU backend update of sokol-gfx!

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ information for HLSL, WGSL and MSL by using a common GLSL output
 for parsing reflection data instead of using the HLSL, WGSL and MSL
 output.
 
+PR: https://github.com/floooh/sokol-tools/pull/110
+
 #### **18-Oct-2023**
 
 > NOTE: this update is required for WebGPU backend update of sokol-gfx!

--- a/test/issue_109.glsl
+++ b/test/issue_109.glsl
@@ -1,0 +1,36 @@
+@ctype mat4 hmm_mat4
+
+@vs vs
+uniform vs_params {
+    mat4 mvp;
+};
+
+in vec4 pos;
+in vec2 texcoord0;
+
+out vec2 uv;
+
+void main() {
+    gl_Position = mvp * pos;
+    uv = texcoord0 * 5.0;
+}
+@end
+
+@fs fs
+uniform texture2D u_atlas_texture;
+uniform texture2D u_atlas_outline;
+uniform sampler u_atlas_sampler;
+
+in vec2 uv;
+out vec4 frag_color;
+
+void main() {
+  vec2 atlas_size = vec2(textureSize(sampler2D(u_atlas_texture, u_atlas_sampler), 0));
+  vec2 v_texture_coord = uv / atlas_size;
+  vec4 fill = texture(sampler2D(u_atlas_texture, u_atlas_sampler), v_texture_coord);
+  vec4 outline = texture(sampler2D(u_atlas_outline, u_atlas_sampler), v_texture_coord);
+  frag_color = fill + outline * (1.0 - fill.a);
+}
+@end
+
+@program texcube vs fs


### PR DESCRIPTION
Previously the output of the SPIRVCross HLSL/MSL/WGSL pass were used as input to the reflection parsing, which required to create dummy samplers, which in turn could lead to issues like https://github.com/floooh/sokol-tools/issues/109.

The new approach uses common SPIRVCross GLSL output for the reflection parsing (which doesn't require to deal with dummy samplers and seems to produce the correct output for parsing the reflection data - also leading to simpler code).