### PR TITLE
StorageBuffer::Num shold match SG_MAX_SHADERSTAGE_STORAGE_BUFFERS

### DIFF
--- a/src/shdc/types/reflection/storage_buffer.h
+++ b/src/shdc/types/reflection/storage_buffer.h
@@ -7,7 +7,7 @@
 namespace shdc::refl {
 
 struct StorageBuffer {
-    static const int Num = 4;   // must be identical with SG_MAX_SHADERSTAGE_STORAGE_BUFFERS
+    static const int Num = 8;   // must be identical with SG_MAX_SHADERSTAGE_STORAGE_BUFFERS
     ShaderStage::Enum stage = ShaderStage::Invalid;
     int slot = -1;
     std::string inst_name;


### PR DESCRIPTION
This bit me today while doing some experiments with the new storage buffer support :D

`StorageBuffer::Num == 4` while `SG_MAX_SHADERSTAGE_STORAGE_BUFFERS == 8`, causing the `sg_shader_desc` to not mark storage buffers `4..8` as used (and `sokol_gfx.h` to give a validation error) even when they compile just fine and are enumerated by the `*_storagebuffer_slot` reflection function. oops!