### PR TITLE
fix array_count for jai generator

### DIFF
--- a/src/shdc/generators/sokoljai.cc
+++ b/src/shdc/generators/sokoljai.cc
@@ -244,7 +244,7 @@ void SokolJaiGenerator::gen_shader_desc_func(const GenInput& gen, const ProgramR
                                     const std::string un = fmt::format("{}.uniforms[{}]", ubn, u_index);
                                     l("{}.name = \"{}.{}\";\n", un, ub->inst_name, u.name);
                                     l("{}.type = {};\n", un, uniform_type(u.type));
-                                    l(".array_count = {};\n", un, u.array_count);
+                                    l("{}.array_count = {};\n", un, u.array_count);
                                 }
                             }
                         }


### PR DESCRIPTION
the jai generator was missing a `{}` in uniform array_count, this fixes it.