### PR TITLE
fixed YamlGenerator's flattened uniform block reflection

### DIFF
--- a/src/shdc/generators/yaml.cc
+++ b/src/shdc/generators/yaml.cc
@@ -132,9 +132,9 @@ void YamlGenerator::gen_uniform_block(const UniformBlock& ub) {
     l_open("uniforms:\n");
     if (ub.flattened) {
         l_open("-\n");
-        l("name: {}\n", ub.struct_info.struct_items[0].name);
+        l("name: {}\n", ub.struct_info.name);
         l("type: {}\n", flattened_uniform_type(ub.struct_info.struct_items[0].type));
-        l("array_count: {}\n", roundup(ub.struct_info.struct_items[0].size, 16) / 16);
+        l("array_count: {}\n", roundup(ub.struct_info.size, 16) / 16);
         l("offset: 0\n");
         l_close();
     } else {


### PR DESCRIPTION
Hi!

I finally got around to updating sokol, everything is great (and a huge thank you and the community for these amazing improvements!!), but unfortunately I found a small problem with sokol-shdc, or more precisely with YamlGenerator.

The thing is that it generates incorrect reflection for the flattened uniform blocks.

For example, consider the original structure:
```glsl
layout (std140, binding = 3) uniform NodeParamsTransmittance {
    vec4 color;
    vec4 metalness_roughness_normalscale_aostrength;
    vec4 alphacutoff_enableblending_padding2;
    vec4 specularcolor_specularintensity;
    vec4 emissive_ior;
    vec4 attenuationfactor_padding1;
    vec4 thickness_transmission_numbounce_padding1;
    vec4 dispersion_ssr;
} u_node_params;
```

In GLSL 410 it is transformed into the following form:
```glsl
uniform vec4 NodeParamsTransmittance[8];
```

The generator works like this:
```yaml
              slot: 3
              size: 128
              struct_name: NodeParamsTransmittance
              inst_name: u_node_params
              uniforms:
                -
                  name: color
                  type: vec4
                  array_count: 1
                  offset: 0
```

Previously it worked like this, and it seems that this behavior (which began to change in fd9a675db) was IMHO more correct:
```yaml
             slot: 3
              size: 128
              struct_name: NodeParamsTransmittance
              inst_name: u_node_params
              uniforms:
                -
                  name: NodeParamsTransmittance
                  type: FLOAT4
                  array_count: 8
                  offset: 0
```

I would like to propose to return the original behavior, that is, reflect uniform block as if it consists of a single array field, having the name of the block itself.

If such changes were made intentionally, I suggest expanding the output, leaving all members of the block, and adding a flag that the block is flattened, or something like that :)