### PR TITLE
Generating bare_yaml output with the --reflection option includes unflattened uniform block data

### DIFF
--- a/src/shdc/generators/yaml.cc
+++ b/src/shdc/generators/yaml.cc
@@ -63,6 +63,15 @@ ErrMsg YamlGenerator::generate(const GenInput& gen) {
                         }
                         l_close();
                     }
+                    if (gen.args.reflection) {
+                        if (refl.bindings.uniform_blocks.size() > 0) {
+                            l_open("uniform_blocks_refl:\n");
+                            for (const auto& uniform_block: refl.bindings.uniform_blocks) {
+                                gen_uniform_block_refl(uniform_block);
+                            }
+                            l_close();
+                        }
+                    }
                     if (refl.bindings.storage_buffers.size() > 0) {
                         l_open("storage_buffers:\n");
                         for (const auto& sbuf: refl.bindings.storage_buffers) {
@@ -144,6 +153,25 @@ void YamlGenerator::gen_uniform_block(const UniformBlock& ub) {
             l("offset: {}\n", u.offset);
             l_close();
         }
+    }
+    l_close();
+    l_close();
+}
+
+void YamlGenerator::gen_uniform_block_refl(const UniformBlock& ub) {
+    l_open("-\n");
+    l("slot: {}\n", ub.slot);
+    l("size: {}\n", roundup(ub.struct_info.size, 16));
+    l("struct_name: {}\n", ub.struct_info.name);
+    l("inst_name: {}\n", ub.inst_name);
+    l_open("uniforms:\n");
+    for (const Type& u: ub.struct_info.struct_items) {
+        l_open("-\n");
+        l("name: {}\n", u.name);
+        l("type: {}\n", uniform_type(u.type));
+        l("array_count: {}\n", u.array_count);
+        l("offset: {}\n", u.offset);
+        l_close();
     }
     l_close();
     l_close();

--- a/src/shdc/generators/yaml.cc
+++ b/src/shdc/generators/yaml.cc
@@ -59,18 +59,9 @@ ErrMsg YamlGenerator::generate(const GenInput& gen) {
                     if (refl.bindings.uniform_blocks.size() > 0) {
                         l_open("uniform_blocks:\n");
                         for (const auto& uniform_block: refl.bindings.uniform_blocks) {
-                            gen_uniform_block(uniform_block);
+                            gen_uniform_block(gen, uniform_block);
                         }
                         l_close();
-                    }
-                    if (gen.args.reflection) {
-                        if (refl.bindings.uniform_blocks.size() > 0) {
-                            l_open("uniform_blocks_refl:\n");
-                            for (const auto& uniform_block: refl.bindings.uniform_blocks) {
-                                gen_uniform_block_refl(uniform_block);
-                            }
-                            l_close();
-                        }
                     }
                     if (refl.bindings.storage_buffers.size() > 0) {
                         l_open("storage_buffers:\n");
@@ -130,7 +121,7 @@ void YamlGenerator::gen_attr(const StageAttr& att) {
     l_close();
 }
 
-void YamlGenerator::gen_uniform_block(const UniformBlock& ub) {
+void YamlGenerator::gen_uniform_block(const GenInput& gen, const UniformBlock& ub) {
     l_open("-\n");
     l("slot: {}\n", ub.slot);
     l("size: {}\n", roundup(ub.struct_info.size, 16));
@@ -155,16 +146,14 @@ void YamlGenerator::gen_uniform_block(const UniformBlock& ub) {
         }
     }
     l_close();
+    if (gen.args.reflection) {
+        gen_uniform_block_refl(ub);
+    }
     l_close();
 }
 
 void YamlGenerator::gen_uniform_block_refl(const UniformBlock& ub) {
-    l_open("-\n");
-    l("slot: {}\n", ub.slot);
-    l("size: {}\n", roundup(ub.struct_info.size, 16));
-    l("struct_name: {}\n", ub.struct_info.name);
-    l("inst_name: {}\n", ub.inst_name);
-    l_open("uniforms:\n");
+    l_open("members:\n");
     for (const Type& u: ub.struct_info.struct_items) {
         l_open("-\n");
         l("name: {}\n", u.name);
@@ -173,7 +162,6 @@ void YamlGenerator::gen_uniform_block_refl(const UniformBlock& ub) {
         l("offset: {}\n", u.offset);
         l_close();
     }
-    l_close();
     l_close();
 }
 

--- a/src/shdc/generators/yaml.h
+++ b/src/shdc/generators/yaml.h
@@ -14,7 +14,7 @@ protected:
     virtual std::string sampler_type(refl::SamplerType::Enum e);
 private:
     void gen_attr(const refl::StageAttr& attr);
-    void gen_uniform_block(const refl::UniformBlock& ub);
+    void gen_uniform_block(const GenInput& gen, const refl::UniformBlock& ub);
     void gen_uniform_block_refl(const refl::UniformBlock& ub);
     void gen_storage_buffer(const refl::StorageBuffer& sbuf);
     void gen_image(const refl::Image& img);

--- a/src/shdc/generators/yaml.h
+++ b/src/shdc/generators/yaml.h
@@ -15,6 +15,7 @@ protected:
 private:
     void gen_attr(const refl::StageAttr& attr);
     void gen_uniform_block(const refl::UniformBlock& ub);
+    void gen_uniform_block_refl(const refl::UniformBlock& ub);
     void gen_storage_buffer(const refl::StorageBuffer& sbuf);
     void gen_image(const refl::Image& img);
     void gen_sampler(const refl::Sampler& smp);

--- a/src/shdc/reflection.cc
+++ b/src/shdc/reflection.cc
@@ -191,7 +191,8 @@ StageReflection Reflection::parse_snippet_reflection(const Compiler& compiler, c
         if (refl_ub.inst_name.empty()) {
             refl_ub.inst_name = compiler.get_fallback_name(ub_res.id);
         }
-        refl_ub.flattened = Spirvcross::can_flatten_uniform_block(compiler, ub_res);
+        // refl_ub.flattened = Spirvcross::can_flatten_uniform_block(compiler, ub_res);
+        refl_ub.flattened = false;
         refl_ub.struct_info = parse_toplevel_struct(compiler, ub_res, out_error);
         if (out_error.valid()) {
             return refl;

--- a/src/shdc/reflection.cc
+++ b/src/shdc/reflection.cc
@@ -191,8 +191,7 @@ StageReflection Reflection::parse_snippet_reflection(const Compiler& compiler, c
         if (refl_ub.inst_name.empty()) {
             refl_ub.inst_name = compiler.get_fallback_name(ub_res.id);
         }
-        // refl_ub.flattened = Spirvcross::can_flatten_uniform_block(compiler, ub_res);
-        refl_ub.flattened = false;
+        refl_ub.flattened = Spirvcross::can_flatten_uniform_block(compiler, ub_res);
         refl_ub.struct_info = parse_toplevel_struct(compiler, ub_res, out_error);
         if (out_error.valid()) {
             return refl;


### PR DESCRIPTION
In some cases it's useful to be able to look at the layout of the actual unflattened uniform blocks, this adds access to that data to the `bare_yaml` output when the `--reflection` argument is used.

Example output:

```
uniform_blocks:
  -
    slot: 0
    size: 144
    struct_name: vs_params
    inst_name: _19
    uniforms:
      -
        name: vs_params
        type: vec4
        array_count: 9
        offset: 0
uniform_blocks_refl:
  -
    slot: 0
    size: 144
    struct_name: vs_params
    inst_name: _19
    uniforms:
      -
        name: u_projViewMatrix
        type: mat4
        array_count: 0
        offset: 0
      -
        name: u_modelMatrix
        type: mat4
        array_count: 0
        offset: 64
      -
        name: u_color
        type: vec4
        array_count: 0
        offset: 128
```