### PR TITLE
Adding the type to Vertex Attributes in the bare yaml reflection

### DIFF
--- a/src/shdc/generators/yaml.cc
+++ b/src/shdc/generators/yaml.cc
@@ -118,6 +118,7 @@ void YamlGenerator::gen_attr(const StageAttr& att) {
     l("name: {}\n", att.name);
     l("sem_name: {}\n", att.sem_name);
     l("sem_index: {}\n", att.sem_index);
+    l("type: {}\n", uniform_type(att.type_info.type));
     l_close();
 }
 

--- a/src/shdc/reflection.cc
+++ b/src/shdc/reflection.cc
@@ -25,6 +25,32 @@ using namespace spirv_cross;
 
 namespace shdc::refl {
 
+static const Type::Enum bool_types[4][4] = {
+    { Type::Bool,    Type::Bool2,   Type::Bool3,   Type::Bool4 },
+    { Type::Invalid, Type::Invalid, Type::Invalid, Type::Invalid },
+    { Type::Invalid, Type::Invalid, Type::Invalid, Type::Invalid },
+    { Type::Invalid, Type::Invalid, Type::Invalid, Type::Invalid },
+};
+static const Type::Enum int_types[4][4] = {
+    { Type::Int,     Type::Int2,    Type::Int3,    Type::Int4 },
+    { Type::Invalid, Type::Invalid, Type::Invalid, Type::Invalid },
+    { Type::Invalid, Type::Invalid, Type::Invalid, Type::Invalid },
+    { Type::Invalid, Type::Invalid, Type::Invalid, Type::Invalid },
+};
+static const Type::Enum uint_types[4][4] = {
+    { Type::UInt,    Type::UInt2,   Type::UInt3,   Type::UInt4 },
+    { Type::Invalid, Type::Invalid, Type::Invalid, Type::Invalid },
+    { Type::Invalid, Type::Invalid, Type::Invalid, Type::Invalid },
+    { Type::Invalid, Type::Invalid, Type::Invalid, Type::Invalid },
+};
+static const Type::Enum float_types[4][4] = {
+    { Type::Float,  Type::Float2, Type::Float3, Type::Float4 },
+    { Type::Mat2x1, Type::Mat2x2, Type::Mat2x3, Type::Mat2x4 },
+    { Type::Mat3x1, Type::Mat3x2, Type::Mat3x3, Type::Mat3x4 },
+    { Type::Mat4x1, Type::Mat4x2, Type::Mat4x3, Type::Mat4x4 },
+};
+
+
 // check that a program's vertex shader outputs match the fragment shader inputs
 // FIXME: this should also check the attribute's type
 static ErrMsg validate_linking(const Input& inp, const Program& prog, const ProgramReflection& prog_refl) {
@@ -171,6 +197,37 @@ StageReflection Reflection::parse_snippet_reflection(const Compiler& compiler, c
         refl_attr.sem_name = "TEXCOORD";
         refl_attr.sem_index = refl_attr.slot;
         refl_attr.snippet_name = snippet.name;
+
+        // get the attribute type!
+        const SPIRType& attr_type = compiler.get_type(res_attr.type_id);
+        Type out;
+        out.name = refl_attr.name;
+        out.type = Type::Invalid;
+        uint32_t col_idx = attr_type.columns - 1;
+        uint32_t vec_idx = attr_type.vecsize - 1;
+        if ((col_idx < 4) && (vec_idx < 4)) {
+            switch (attr_type.basetype) {
+                case SPIRType::Boolean:
+                    out.type = bool_types[col_idx][vec_idx];
+                    break;
+                case SPIRType::Int:
+                    out.type = int_types[col_idx][vec_idx];
+                    break;
+                case SPIRType::UInt:
+                    out.type = uint_types[col_idx][vec_idx];
+                    break;
+                case SPIRType::Float:
+                    out.type = float_types[col_idx][vec_idx];
+                    break;
+                case SPIRType::Struct:
+                    out.type = Type::Struct;
+                    break;
+                default:
+                    break;
+            }
+        }
+        refl_attr.type_info = out;
+
         refl.inputs[refl_attr.slot] = refl_attr;
     }
     for (const Resource& res_attr: shd_resources.stage_outputs) {
@@ -180,6 +237,9 @@ StageReflection Reflection::parse_snippet_reflection(const Compiler& compiler, c
         refl_attr.sem_name = "TEXCOORD";
         refl_attr.sem_index = refl_attr.slot;
         refl_attr.snippet_name = snippet.name;
+
+        const SPIRType& attr_type = compiler.get_type(res_attr.type_id);
+
         refl.outputs[refl_attr.slot] = refl_attr;
     }
     // uniform blocks
@@ -191,7 +251,7 @@ StageReflection Reflection::parse_snippet_reflection(const Compiler& compiler, c
         if (refl_ub.inst_name.empty()) {
             refl_ub.inst_name = compiler.get_fallback_name(ub_res.id);
         }
-        refl_ub.flattened = Spirvcross::can_flatten_uniform_block(compiler, ub_res);
+        // refl_ub.flattened = Spirvcross::can_flatten_uniform_block(compiler, ub_res);
         refl_ub.struct_info = parse_toplevel_struct(compiler, ub_res, out_error);
         if (out_error.valid()) {
             return refl;
@@ -383,31 +443,6 @@ Bindings Reflection::merge_bindings(const std::vector<Bindings>& in_bindings, Er
     }
     return out_bindings;
 }
-
-static const Type::Enum bool_types[4][4] = {
-    { Type::Bool,    Type::Bool2,   Type::Bool3,   Type::Bool4 },
-    { Type::Invalid, Type::Invalid, Type::Invalid, Type::Invalid },
-    { Type::Invalid, Type::Invalid, Type::Invalid, Type::Invalid },
-    { Type::Invalid, Type::Invalid, Type::Invalid, Type::Invalid },
-};
-static const Type::Enum int_types[4][4] = {
-    { Type::Int,     Type::Int2,    Type::Int3,    Type::Int4 },
-    { Type::Invalid, Type::Invalid, Type::Invalid, Type::Invalid },
-    { Type::Invalid, Type::Invalid, Type::Invalid, Type::Invalid },
-    { Type::Invalid, Type::Invalid, Type::Invalid, Type::Invalid },
-};
-static const Type::Enum uint_types[4][4] = {
-    { Type::UInt,    Type::UInt2,   Type::UInt3,   Type::UInt4 },
-    { Type::Invalid, Type::Invalid, Type::Invalid, Type::Invalid },
-    { Type::Invalid, Type::Invalid, Type::Invalid, Type::Invalid },
-    { Type::Invalid, Type::Invalid, Type::Invalid, Type::Invalid },
-};
-static const Type::Enum float_types[4][4] = {
-    { Type::Float,  Type::Float2, Type::Float3, Type::Float4 },
-    { Type::Mat2x1, Type::Mat2x2, Type::Mat2x3, Type::Mat2x4 },
-    { Type::Mat3x1, Type::Mat3x2, Type::Mat3x3, Type::Mat3x4 },
-    { Type::Mat4x1, Type::Mat4x2, Type::Mat4x3, Type::Mat4x4 },
-};
 
 Type Reflection::parse_struct_item(const Compiler& compiler, const TypeID& type_id, const TypeID& base_type_id, uint32_t item_index, ErrMsg& out_error) {
     const SPIRType& base_type = compiler.get_type(base_type_id);

--- a/src/shdc/reflection.cc
+++ b/src/shdc/reflection.cc
@@ -251,7 +251,7 @@ StageReflection Reflection::parse_snippet_reflection(const Compiler& compiler, c
         if (refl_ub.inst_name.empty()) {
             refl_ub.inst_name = compiler.get_fallback_name(ub_res.id);
         }
-        // refl_ub.flattened = Spirvcross::can_flatten_uniform_block(compiler, ub_res);
+        refl_ub.flattened = Spirvcross::can_flatten_uniform_block(compiler, ub_res);
         refl_ub.struct_info = parse_toplevel_struct(compiler, ub_res, out_error);
         if (out_error.valid()) {
             return refl;

--- a/src/shdc/types/reflection/stage_attr.h
+++ b/src/shdc/types/reflection/stage_attr.h
@@ -1,5 +1,6 @@
 #pragma once
 #include <string>
+#include "type.h"
 
 namespace shdc::refl {
 
@@ -10,6 +11,7 @@ struct StageAttr {
     std::string sem_name;
     int sem_index = 0;
     std::string snippet_name;
+    Type type_info;
 
     bool equals(const StageAttr& rhs, bool with_snippet_name) const;
     void dump_debug(const std::string& indent) const;


### PR DESCRIPTION
I don't know if this would be useful, but someone in the #gamedev channel on the Zig discord was talking about wanting to get the type of a vertex attribute and I saw that it wasn't being included yet, this adds some type info to the `StageAttr` struct and outputs the type in generated yaml files just to start.