### PR TITLE
change backendWgsl to correct name backendWgpu in Nim generator

### DIFF
--- a/src/shdc/generators/sokolnim.cc
+++ b/src/shdc/generators/sokolnim.cc
@@ -496,7 +496,7 @@ std::string SokolNimGenerator::backend(Slang::Enum e) {
         case Slang::METAL_SIM:
             return "backendMetalSimulator";
         case Slang::WGSL:
-            return "backendWgsl";
+            return "backendWgpu";
         default:
             return "<INVALID>";
     }


### PR DESCRIPTION
A Nim project was failing to compile using shaders produced for the wgsl backend, so I believe this will do the trick!