### PR TITLE
c-generator: add the module tag back into attr and bindslot defines.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,15 @@
 CHANGELOG
 =========
 
+#### **10-Dec-2024**
+
+Another minor regression fix: in the C code generator, attribute and bindslot
+defines now include the `@module` tag again, this can be used to avoid name
+conflicts across shader files.
+
+See issue https://github.com/floooh/sokol-tools/issues/160 and PR [FIXME]
+for details!
+
 #### **09-Nov-2024**
 
 Important regression fix: shaders which used textures/samplers both on the vertex-

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 #
 # project: sokol-tools
 #
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.20)
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_OSX_DEPLOYMENT_TARGET "10.13" CACHE STRING "")
 project(sokol-tools)

--- a/src/shdc/generators/sokolc.cc
+++ b/src/shdc/generators/sokolc.cc
@@ -679,23 +679,23 @@ std::string SokolCGenerator::struct_name(const std::string& name) {
 }
 
 std::string SokolCGenerator::vertex_attr_name(const std::string& prog_name, const StageAttr& attr) {
-    return fmt::format("ATTR_{}_{}", prog_name, attr.name);
+    return fmt::format("ATTR_{}{}_{}", mod_prefix, prog_name, attr.name);
 }
 
 std::string SokolCGenerator::image_bind_slot_name(const Image& img) {
-    return fmt::format("IMG_{}", img.name);
+    return fmt::format("IMG_{}{}", mod_prefix, img.name);
 }
 
 std::string SokolCGenerator::sampler_bind_slot_name(const Sampler& smp) {
-    return fmt::format("SMP_{}", smp.name);
+    return fmt::format("SMP_{}{}", mod_prefix, smp.name);
 }
 
 std::string SokolCGenerator::uniform_block_bind_slot_name(const UniformBlock& ub) {
-    return fmt::format("UB_{}", ub.name);
+    return fmt::format("UB_{}{}", mod_prefix, ub.name);
 }
 
 std::string SokolCGenerator::storage_buffer_bind_slot_name(const StorageBuffer& sbuf) {
-    return fmt::format("SBUF_{}", sbuf.name);
+    return fmt::format("SBUF_{}{}", mod_prefix, sbuf.name);
 }
 
 std::string SokolCGenerator::vertex_attr_definition(const std::string& prog_name, const StageAttr& attr) {


### PR DESCRIPTION
This is a regression fix for https://github.com/floooh/sokol-tools/issues/160