### PR TITLE
Fix error in readme.

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,8 +61,7 @@ The executables for Linux **must** be compiled via Docker since they use
 static linking with musl, and Alpine Linux in Docker is the easiest option for this.
 
 ```
-> cd docker
-> ./build.sh
+> ./build_docker.sh
 ```
 The compiled Linux executable will be in the same directory (docker/)
 


### PR DESCRIPTION
Fixes a mistake in the Readme regarding how to build on linux.

```
cd docker/
./build.sh
```

There is no docker/ folder and the build script is just ./build_docker.sh.