### PR TITLE
GLSL output: don't remap storage buffer bindings to 0..16

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,16 @@
 CHANGELOG
 =========
 
-#### **20-Jan-2024**
+#### **23-Jan-2025**
+
+GLSL v430 output will no longer remap storage buffer bindings to the slot
+range 0..15 but instead only use the slot range 0..7 (this is ok because sokol_gfx.h
+only allows to use up to 8 storage buffer bindings anyway). This change allows
+sokol_gfx.h to run on min-spec GL drivers that only allow the minimal number of
+storage buffer bindings (see sokol issue [#1193](https://github.com/floooh/sokol/issues/1193)
+for details).
+
+#### **20-Jan-2025**
 
 The binary distribution repo https://github.com/floooh/sokol-tools-bin now also
 has a binary for ARM64 Linux under the path `bin/linux_arm64/sokol-shdc`).

--- a/src/shdc/reflection.cc
+++ b/src/shdc/reflection.cc
@@ -273,13 +273,7 @@ StageReflection Reflection::parse_snippet_reflection(const Compiler& compiler, c
         const int slot = compiler.get_decoration(sbuf_res.id, spv::DecorationBinding);
         const Bindings::Type res_type = Bindings::Type::STORAGE_BUFFER;
         StorageBuffer refl_sbuf;
-        refl_sbuf.stage = refl.stage;
-        refl_sbuf.hlsl_register_t_n = slot + Bindings::base_slot(Slang::HLSL5, refl.stage, res_type);
-        refl_sbuf.msl_buffer_n = slot + Bindings::base_slot(Slang::METAL_SIM, refl.stage, res_type);
-        refl_sbuf.wgsl_group1_binding_n = slot + Bindings::base_slot(Slang::WGSL, refl.stage, res_type);
-        refl_sbuf.glsl_binding_n = slot + Bindings::base_slot(Slang::GLSL430, refl.stage, res_type);
         refl_sbuf.inst_name = compiler.get_name(sbuf_res.id);
-        refl_sbuf.readonly = compiler.get_buffer_block_flags(sbuf_res.id).get(spv::DecorationNonWritable);
         if (refl_sbuf.inst_name.empty()) {
             refl_sbuf.inst_name = compiler.get_fallback_name(sbuf_res.id);
         }
@@ -293,6 +287,14 @@ StageReflection Reflection::parse_snippet_reflection(const Compiler& compiler, c
             out_error = inp.error(0, fmt::format("no binding found for storagebuffer '{}' (might be unused in shader code?)\n", refl_sbuf.name));
             return refl;
         }
+        refl_sbuf.stage = refl.stage;
+        refl_sbuf.hlsl_register_t_n = slot + Bindings::base_slot(Slang::HLSL5, refl.stage, res_type);
+        refl_sbuf.msl_buffer_n = slot + Bindings::base_slot(Slang::METAL_SIM, refl.stage, res_type);
+        refl_sbuf.wgsl_group1_binding_n = slot + Bindings::base_slot(Slang::WGSL, refl.stage, res_type);
+        // SPECIAL CASE GL: the GL storage buffer bind slot is identical with the sokol-bind slot
+        // since GL also has a common bindspace across shader stages for storage buffers
+        refl_sbuf.glsl_binding_n = refl_sbuf.sokol_slot;
+        refl_sbuf.readonly = compiler.get_buffer_block_flags(sbuf_res.id).get(spv::DecorationNonWritable);
         refl.bindings.storage_buffers.push_back(refl_sbuf);
     }
 

--- a/src/shdc/spirvcross.cc
+++ b/src/shdc/spirvcross.cc
@@ -78,7 +78,7 @@ static void fix_bind_slots(Compiler& compiler, Snippet::Type snippet_type, Slang
         for (const Resource& res: shader_resources.storage_buffers) {
             compiler.set_decoration(res.id, spv::DecorationDescriptorSet, 0);
             // special case: for GL storage buffers we actually keep the original binding,
-            // so that the the GL bind slot is (0..7) across all stages
+            // so that the GL bind slot is (0..7) across all stages
             if (!Slang::is_glsl(slang)) {
                 compiler.set_decoration(res.id, spv::DecorationBinding, binding++);
             }

--- a/src/shdc/spirvcross.cc
+++ b/src/shdc/spirvcross.cc
@@ -77,7 +77,11 @@ static void fix_bind_slots(Compiler& compiler, Snippet::Type snippet_type, Slang
         uint32_t binding = Bindings::base_slot(slang, stage, Bindings::Type::STORAGE_BUFFER);
         for (const Resource& res: shader_resources.storage_buffers) {
             compiler.set_decoration(res.id, spv::DecorationDescriptorSet, 0);
-            compiler.set_decoration(res.id, spv::DecorationBinding, binding++);
+            // special case: for GL storage buffers we actually keep the original binding,
+            // so that the the GL bind slot is (0..7) across all stages
+            if (!Slang::is_glsl(slang)) {
+                compiler.set_decoration(res.id, spv::DecorationBinding, binding++);
+            }
         }
     }
 }

--- a/src/shdc/types/reflection/bindings.h
+++ b/src/shdc/types/reflection/bindings.h
@@ -88,10 +88,6 @@ inline uint32_t Bindings::base_slot(Slang::Enum slang, ShaderStage::Enum stage, 
                 res = MaxUniformBlocks;
             } else if (Slang::is_hlsl(slang)) {
                 res = MaxImages;
-            } else if (Slang::is_glsl(slang)) {
-                if (ShaderStage::is_fs(stage)) {
-                    res = MaxStorageBuffers;
-                }
             } else if (Slang::is_wgsl(slang)) {
                 res = MaxImages + MaxSamplers;
                 if (ShaderStage::is_fs(stage)) {


### PR DESCRIPTION
...instead use the original bindings from 0..7 across all shader stages. This allows compatibility with lower end GL drivers which only support 8 storage buffers.