### PR TITLE
Extract vertex attribute base type into code-generated sg_shader_desc.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,15 @@
 CHANGELOG
 =========
 
+#### **15-Mar-2025**
+
+Write the 'vertex attribute base type' as part of the reflection info
+in the code-generated `sg_shader_desc`. Requires the sokol update:
+
+https://github.com/floooh/sokol/pull/1222
+
+Implemented in PR: https://github.com/floooh/sokol-tools/pull/176
+
 #### **05-Mar-2025**
 
 Add support for compute shaders.

--- a/src/shdc/generators/generator.h
+++ b/src/shdc/generators/generator.h
@@ -68,6 +68,7 @@ protected:
     virtual std::string shader_source_array_name(const std::string& snippet_name, Slang::Enum slang) { return "INVALID"; };
 
     virtual std::string shader_stage(refl::ShaderStage::Enum e) { assert(false && "implement me"); return ""; };
+    virtual std::string attr_basetype(refl::Type::Enum e) { assert(false && "implement me"); return ""; };
     virtual std::string uniform_type(refl::Type::Enum e) { assert(false && "implement me"); return ""; };
     virtual std::string flattened_uniform_type(refl::Type::Enum e) { assert(false && "implement me"); return ""; };
     virtual std::string image_type(refl::ImageType::Enum e) { assert(false && "implement me"); return ""; };

--- a/src/shdc/generators/sokolc.cc
+++ b/src/shdc/generators/sokolc.cc
@@ -295,7 +295,7 @@ void SokolCGenerator::gen_shader_desc_func(const GenInput& gen, const ProgramRef
                 for (int attr_index = 0; attr_index < StageAttr::Num; attr_index++) {
                     const StageAttr& attr = prog.vs().inputs[attr_index];
                     if (attr.slot >= 0) {
-                        l("desc.attrs[{}].base_type = {};\n", attr_basetype(attr.type_info.basetype()));
+                        l("desc.attrs[{}].base_type = {};\n", attr_index, attr_basetype(attr.type_info.basetype()));
                         if (Slang::is_glsl(slang)) {
                             l("desc.attrs[{}].glsl_name = \"{}\";\n", attr_index, attr.name);
                         } else if (Slang::is_hlsl(slang)) {
@@ -608,9 +608,9 @@ std::string SokolCGenerator::shader_stage(ShaderStage::Enum e) {
 
 std::string SokolCGenerator::attr_basetype(Type::Enum e) {
     switch (e) {
-        case Type::Float:   return "SG_SHADERVERTEXATTRBASETYPE_FLOAT";
-        case Type::Int:     return "SG_SHADERVERTEXATTRBASETYPE_INT";
-        case Type::UInt:    return "SG_SHADERVERTEXATTRBASETYPE_UINT";
+        case Type::Float:   return "SG_SHADERATTRBASETYPE_FLOAT";
+        case Type::Int:     return "SG_SHADERATTRBASETYPE_INT";
+        case Type::UInt:    return "SG_SHADERATTRBASETYPE_UINT";
         default: return "INVALID";
     }
 }

--- a/src/shdc/generators/sokolc.cc
+++ b/src/shdc/generators/sokolc.cc
@@ -295,6 +295,7 @@ void SokolCGenerator::gen_shader_desc_func(const GenInput& gen, const ProgramRef
                 for (int attr_index = 0; attr_index < StageAttr::Num; attr_index++) {
                     const StageAttr& attr = prog.vs().inputs[attr_index];
                     if (attr.slot >= 0) {
+                        l("desc.attrs[{}].base_type = {};\n", attr_basetype(attr.type_info.basetype()));
                         if (Slang::is_glsl(slang)) {
                             l("desc.attrs[{}].glsl_name = \"{}\";\n", attr_index, attr.name);
                         } else if (Slang::is_hlsl(slang)) {
@@ -601,6 +602,15 @@ std::string SokolCGenerator::shader_stage(ShaderStage::Enum e) {
         case ShaderStage::Vertex: return "SG_SHADERSTAGE_VERTEX";
         case ShaderStage::Fragment: return "SG_SHADERSTAGE_FRAGMENT";
         case ShaderStage::Compute: return "SG_SHADERSTAGE_COMPUTE";
+        default: return "INVALID";
+    }
+}
+
+std::string SokolCGenerator::attr_basetype(Type::Enum e) {
+    switch (e) {
+        case Type::Float:   return "SG_SHADERVERTEXATTRBASETYPE_FLOAT";
+        case Type::Int:     return "SG_SHADERVERTEXATTRBASETYPE_INT";
+        case Type::UInt:    return "SG_SHADERVERTEXATTRBASETYPE_UINT";
         default: return "INVALID";
     }
 }

--- a/src/shdc/generators/sokolc.h
+++ b/src/shdc/generators/sokolc.h
@@ -34,6 +34,7 @@ protected:
     virtual std::string shader_source_array_name(const std::string& snippet_name, Slang::Enum slang);
     virtual std::string get_shader_desc_help(const std::string& prog_name);
     virtual std::string shader_stage(refl::ShaderStage::Enum e);
+    virtual std::string attr_basetype(refl::Type::Enum e);
     virtual std::string uniform_type(refl::Type::Enum e);
     virtual std::string flattened_uniform_type(refl::Type::Enum e);
     virtual std::string image_type(refl::ImageType::Enum e);

--- a/src/shdc/generators/sokolc3.cc
+++ b/src/shdc/generators/sokolc3.cc
@@ -235,6 +235,7 @@ void SokolC3Generator::gen_shader_desc_func(const GenInput& gen, const ProgramRe
                 for (int attr_index = 0; attr_index < StageAttr::Num; attr_index++) {
                     const StageAttr& attr = prog.vs().inputs[attr_index];
                     if (attr.slot >= 0) {
+                        l("desc.attrs[{}].base_type = {};\n", attr_index, attr_basetype(attr.type_info.basetype()));
                         if (Slang::is_glsl(slang)) {
                             l("desc.attrs[{}].glsl_name = \"{}\";\n", attr_index, attr.name);
                         } else if (Slang::is_hlsl(slang)) {
@@ -390,6 +391,15 @@ std::string SokolC3Generator::shader_stage(const ShaderStage::Enum e) {
         case ShaderStage::Vertex: return "shader_stage::VERTEX";
         case ShaderStage::Fragment: return "shader_stage::FRAGMENT";
         case ShaderStage::Compute: return "shader_stage::COMPUTE";
+        default: return "INVALID";
+    }
+}
+
+std::string SokolC3Generator::attr_basetype(Type::Enum e) {
+    switch (e) {
+        case Type::Float:   return "shader_attr_base_type::FLOAT";
+        case Type::Int:     return "shader_attr_base_type::INT";
+        case Type::UInt:    return "shader_attr_base_type::UINT";
         default: return "INVALID";
     }
 }

--- a/src/shdc/generators/sokolc3.h
+++ b/src/shdc/generators/sokolc3.h
@@ -21,6 +21,7 @@ protected:
     virtual std::string shader_source_array_name(const std::string& snippet_name, Slang::Enum slang);
     virtual std::string get_shader_desc_help(const std::string& prog_name);
     virtual std::string shader_stage(refl::ShaderStage::Enum e);
+    virtual std::string attr_basetype(refl::Type::Enum e);
     virtual std::string uniform_type(refl::Type::Enum e);
     virtual std::string flattened_uniform_type(refl::Type::Enum e);
     virtual std::string image_type(refl::ImageType::Enum e);

--- a/src/shdc/generators/sokold.cc
+++ b/src/shdc/generators/sokold.cc
@@ -244,6 +244,7 @@ void SokolDGenerator::gen_shader_desc_func(const GenInput& gen, const ProgramRef
                 for (int attr_index = 0; attr_index < StageAttr::Num; attr_index++) {
                     const StageAttr& attr = prog.vs().inputs[attr_index];
                     if (attr.slot >= 0) {
+                        l("desc.attrs[{}].base_type = {};\n", attr_index, attr_basetype(attr.type_info.basetype()));
                         if (Slang::is_glsl(slang)) {
                             l("desc.attrs[{}].glsl_name = \"{}\";\n", attr_index, attr.name);
                         } else if (Slang::is_hlsl(slang)) {
@@ -393,6 +394,15 @@ std::string SokolDGenerator::shader_stage(ShaderStage::Enum e) {
         case ShaderStage::Vertex: return "sg.ShaderStage.Vertex";
         case ShaderStage::Fragment: return "sg.ShaderStage.Fragment";
         case ShaderStage::Compute: return "sg.ShaderStage.Compute";
+        default: return "INVALID";
+    }
+}
+
+std::string SokolDGenerator::attr_basetype(Type::Enum e) {
+    switch (e) {
+        case Type::Float:   return "sg.ShaderAttrBaseType.Float";
+        case Type::Int:     return "sg.ShaderAttrBaseType.Int";
+        case Type::UInt:    return "sg.ShaderAttrBaseType.Uint";
         default: return "INVALID";
     }
 }

--- a/src/shdc/generators/sokold.h
+++ b/src/shdc/generators/sokold.h
@@ -21,6 +21,7 @@ protected:
     virtual std::string shader_source_array_name(const std::string& snippet_name, Slang::Enum slang);
     virtual std::string get_shader_desc_help(const std::string& prog_name);
     virtual std::string shader_stage(refl::ShaderStage::Enum e);
+    virtual std::string attr_basetype(refl::Type::Enum e);
     virtual std::string uniform_type(refl::Type::Enum e);
     virtual std::string flattened_uniform_type(refl::Type::Enum e);
     virtual std::string image_type(refl::ImageType::Enum e);

--- a/src/shdc/generators/sokoljai.cc
+++ b/src/shdc/generators/sokoljai.cc
@@ -228,6 +228,7 @@ void SokolJaiGenerator::gen_shader_desc_func(const GenInput& gen, const ProgramR
                 for (int attr_index = 0; attr_index < StageAttr::Num; attr_index++) {
                     const StageAttr& attr = prog.vs().inputs[attr_index];
                     if (attr.slot >= 0) {
+                        l("desc.attrs[{}].base_type = {};\n", attr_index, attr_basetype(attr.type_info.basetype()));
                         if (Slang::is_glsl(slang)) {
                             l("desc.attrs[{}].glsl_name = \"{}\";\n", attr_index, attr.name);
                         } else if (Slang::is_hlsl(slang)) {
@@ -383,6 +384,15 @@ std::string SokolJaiGenerator::shader_stage(ShaderStage::Enum e) {
         case ShaderStage::Vertex: return ".VERTEX";
         case ShaderStage::Fragment: return ".FRAGMENT";
         case ShaderStage::Compute: return ".COMPUTE";
+        default: return "INVALID";
+    }
+}
+
+std::string SokolJaiGenerator::attr_basetype(Type::Enum e) {
+    switch (e) {
+        case Type::Float:   return ".FLOAT";
+        case Type::Int:     return ".INT";
+        case Type::UInt:    return ".UINT";
         default: return "INVALID";
     }
 }

--- a/src/shdc/generators/sokoljai.h
+++ b/src/shdc/generators/sokoljai.h
@@ -21,6 +21,7 @@ protected:
     virtual std::string shader_source_array_name(const std::string& snippet_name, Slang::Enum slang);
     virtual std::string get_shader_desc_help(const std::string& prog_name);
     virtual std::string shader_stage(refl::ShaderStage::Enum e);
+    virtual std::string attr_basetype(refl::Type::Enum e);
     virtual std::string uniform_type(refl::Type::Enum e);
     virtual std::string flattened_uniform_type(refl::Type::Enum e);
     virtual std::string image_type(refl::ImageType::Enum e);

--- a/src/shdc/generators/sokolnim.cc
+++ b/src/shdc/generators/sokolnim.cc
@@ -303,14 +303,15 @@ void SokolNimGenerator::gen_shader_desc_func(const GenInput& gen, const ProgramR
                 l("{}.entry = \"{}\"\n", dsn, refl.entry_point_by_slang(slang));
             }
             if (Slang::is_msl(slang) && prog.has_cs()) {
-                l("result.mtlThreadsPerThreadgroup.x = {};\n", prog.cs().cs_workgroup_size[0]);
-                l("result.mtlThreadsPerThreadgroup.y = {};\n", prog.cs().cs_workgroup_size[1]);
-                l("result.mtlThreadsPerThreadgroup.z = {};\n", prog.cs().cs_workgroup_size[2]);
+                l("result.mtlThreadsPerThreadgroup.x = {}\n", prog.cs().cs_workgroup_size[0]);
+                l("result.mtlThreadsPerThreadgroup.y = {}\n", prog.cs().cs_workgroup_size[1]);
+                l("result.mtlThreadsPerThreadgroup.z = {}\n", prog.cs().cs_workgroup_size[2]);
             }
             if (prog.has_vs()) {
                 for (int attr_index = 0; attr_index < StageAttr::Num; attr_index++) {
                     const StageAttr& attr = prog.vs().inputs[attr_index];
                     if (attr.slot >= 0) {
+                        l("result.attrs[{}].base_type = {}\n", attr_index, attr_basetype(attr.type_info.basetype()));
                         if (Slang::is_glsl(slang)) {
                             l("result.attrs[{}].glslName = \"{}\"\n", attr_index, attr.name);
                         } else if (Slang::is_hlsl(slang)) {
@@ -466,6 +467,15 @@ std::string SokolNimGenerator::shader_stage(ShaderStage::Enum e) {
         case ShaderStage::Vertex: return "shaderStageVertex";
         case ShaderStage::Fragment: return "shaderStageFragment";
         case ShaderStage::Compute: return "shaderStageCompute";
+        default: return "INVALID";
+    }
+}
+
+std::string SokolNimGenerator::attr_basetype(Type::Enum e) {
+    switch (e) {
+        case Type::Float:   return "shaderAttrBaseTypeFloat";
+        case Type::Int:     return "shaderAttrBaseTypeInt";
+        case Type::UInt:    return "shaderAttrBaseTypeUint";
         default: return "INVALID";
     }
 }

--- a/src/shdc/generators/sokolnim.h
+++ b/src/shdc/generators/sokolnim.h
@@ -23,6 +23,7 @@ protected:
     virtual std::string shader_source_array_name(const std::string& snippet_name, Slang::Enum slang);
     virtual std::string get_shader_desc_help(const std::string& prog_name);
     virtual std::string shader_stage(refl::ShaderStage::Enum e);
+    virtual std::string attr_basetype(refl::Type::Enum e);
     virtual std::string uniform_type(refl::Type::Enum e);
     virtual std::string flattened_uniform_type(refl::Type::Enum e);
     virtual std::string image_type(refl::ImageType::Enum e);

--- a/src/shdc/generators/sokolodin.cc
+++ b/src/shdc/generators/sokolodin.cc
@@ -230,14 +230,15 @@ void SokolOdinGenerator::gen_shader_desc_func(const GenInput& gen, const Program
                 l("{}.entry = \"{}\"\n", dsn, refl.entry_point_by_slang(slang));
             }
             if (Slang::is_msl(slang) && prog.has_cs()) {
-                l("desc.mtl_threads_per_threadgroup.x = {};\n", prog.cs().cs_workgroup_size[0]);
-                l("desc.mtl_threads_per_threadgroup.y = {};\n", prog.cs().cs_workgroup_size[1]);
-                l("desc.mtl_threads_per_threadgroup.z = {};\n", prog.cs().cs_workgroup_size[2]);
+                l("desc.mtl_threads_per_threadgroup.x = {}\n", prog.cs().cs_workgroup_size[0]);
+                l("desc.mtl_threads_per_threadgroup.y = {}\n", prog.cs().cs_workgroup_size[1]);
+                l("desc.mtl_threads_per_threadgroup.z = {}\n", prog.cs().cs_workgroup_size[2]);
             }
             if (prog.has_vs()) {
                 for (int attr_index = 0; attr_index < StageAttr::Num; attr_index++) {
                     const StageAttr& attr = prog.vs().inputs[attr_index];
                     if (attr.slot >= 0) {
+                        l("desc.attrs[{}].base_type = {}\n", attr_index, attr_basetype(attr.type_info.basetype()));
                         if (Slang::is_glsl(slang)) {
                             l("desc.attrs[{}].glsl_name = \"{}\"\n", attr_index, attr.name);
                         } else if (Slang::is_hlsl(slang)) {
@@ -509,6 +510,15 @@ std::string SokolOdinGenerator::shader_stage(const ShaderStage::Enum e) {
         case ShaderStage::Vertex: return ".VERTEX";
         case ShaderStage::Fragment: return ".FRAGMENT";
         case ShaderStage::Compute: return ".COMPUTE";
+        default: return "INVALID";
+    }
+}
+
+std::string SokolOdinGenerator::attr_basetype(Type::Enum e) {
+    switch (e) {
+        case Type::Float:   return ".FLOAT";
+        case Type::Int:     return ".INT";
+        case Type::UInt:    return ".UINT";
         default: return "INVALID";
     }
 }

--- a/src/shdc/generators/sokolodin.h
+++ b/src/shdc/generators/sokolodin.h
@@ -31,6 +31,7 @@ protected:
     virtual std::string shader_source_array_name(const std::string& snippet_name, Slang::Enum slang);
     virtual std::string get_shader_desc_help(const std::string& prog_name);
     virtual std::string shader_stage(refl::ShaderStage::Enum e);
+    virtual std::string attr_basetype(refl::Type::Enum e);
     virtual std::string uniform_type(refl::Type::Enum e);
     virtual std::string flattened_uniform_type(refl::Type::Enum e);
     virtual std::string image_type(refl::ImageType::Enum e);

--- a/src/shdc/generators/sokolrust.cc
+++ b/src/shdc/generators/sokolrust.cc
@@ -244,6 +244,7 @@ void SokolRustGenerator::gen_shader_desc_func(const GenInput& gen, const Program
                 for (int attr_index = 0; attr_index < StageAttr::Num; attr_index++) {
                     const StageAttr& attr = prog.vs().inputs[attr_index];
                     if (attr.slot >= 0) {
+                        l("desc.attrs[{}].base_type = {};\n", attr_index, attr_basetype(attr.type_info.basetype()));
                         if (Slang::is_glsl(slang)) {
                             l("desc.attrs[{}].glsl_name = c\"{}\".as_ptr();\n", attr_index, attr.name);
                         } else if (Slang::is_hlsl(slang)) {
@@ -400,6 +401,15 @@ std::string SokolRustGenerator::shader_stage(ShaderStage::Enum e) {
         case ShaderStage::Vertex: return "sg::ShaderStage::Vertex";
         case ShaderStage::Fragment: return "sg::ShaderStage::Fragment";
         case ShaderStage::Compute: return "sg::ShaderStage::Compute";
+        default: return "INVALID";
+    }
+}
+
+std::string SokolRustGenerator::attr_basetype(Type::Enum e) {
+    switch (e) {
+        case Type::Float:   return "sg::ShaderAttrBaseType::Float";
+        case Type::Int:     return "sg::ShaderAttrBaseType::Int";
+        case Type::UInt:    return "sg::ShaderAttrBaseType::Uint";
         default: return "INVALID";
     }
 }

--- a/src/shdc/generators/sokolrust.h
+++ b/src/shdc/generators/sokolrust.h
@@ -21,6 +21,7 @@ protected:
     virtual std::string shader_source_array_name(const std::string& snippet_name, Slang::Enum slang);
     virtual std::string get_shader_desc_help(const std::string& prog_name);
     virtual std::string shader_stage(refl::ShaderStage::Enum e);
+    virtual std::string attr_basetype(refl::Type::Enum e);
     virtual std::string uniform_type(refl::Type::Enum e);
     virtual std::string flattened_uniform_type(refl::Type::Enum e);
     virtual std::string image_type(refl::ImageType::Enum e);

--- a/src/shdc/generators/sokolzig.cc
+++ b/src/shdc/generators/sokolzig.cc
@@ -242,6 +242,7 @@ void SokolZigGenerator::gen_shader_desc_func(const GenInput& gen, const ProgramR
                 for (int attr_index = 0; attr_index < StageAttr::Num; attr_index++) {
                     const StageAttr& attr = prog.vs().inputs[attr_index];
                     if (attr.slot >= 0) {
+                        l("desc.attrs[{}].base_type = {};\n", attr_index, attr_basetype(attr.type_info.basetype()));
                         if (Slang::is_glsl(slang)) {
                             l("desc.attrs[{}].glsl_name = \"{}\";\n", attr_index, attr.name);
                         } else if (Slang::is_hlsl(slang)) {
@@ -398,6 +399,15 @@ std::string SokolZigGenerator::shader_stage(ShaderStage::Enum e) {
         case ShaderStage::Vertex: return ".VERTEX";
         case ShaderStage::Fragment: return ".FRAGMENT";
         case ShaderStage::Compute: return ".COMPUTE";
+        default: return "INVALID";
+    }
+}
+
+std::string SokolZigGenerator::attr_basetype(Type::Enum e) {
+    switch (e) {
+        case Type::Float:   return ".FLOAT";
+        case Type::Int:     return ".INT";
+        case Type::UInt:    return ".UINT";
         default: return "INVALID";
     }
 }

--- a/src/shdc/generators/sokolzig.h
+++ b/src/shdc/generators/sokolzig.h
@@ -29,6 +29,7 @@ protected:
     virtual std::string shader_source_array_name(const std::string& snippet_name, Slang::Enum slang);
     virtual std::string get_shader_desc_help(const std::string& prog_name);
     virtual std::string shader_stage(refl::ShaderStage::Enum e);
+    virtual std::string attr_basetype(refl::Type::Enum e);
     virtual std::string uniform_type(refl::Type::Enum e);
     virtual std::string flattened_uniform_type(refl::Type::Enum e);
     virtual std::string image_type(refl::ImageType::Enum e);

--- a/src/shdc/generators/yaml.cc
+++ b/src/shdc/generators/yaml.cc
@@ -128,6 +128,7 @@ void YamlGenerator::gen_attr(const StageAttr& attr, Slang::Enum slang) {
     l_open("-\n");
     l("slot: {}\n", attr.slot);
     l("type: {}\n", uniform_type(attr.type_info.type));
+    l("base_type: {}\n", attr_basetype(attr.type_info.basetype()));
     if (Slang::is_glsl(slang)) {
         l("glsl_name: {}\n", attr.name);
     } else if (Slang::is_hlsl(slang)) {
@@ -289,6 +290,10 @@ std::string YamlGenerator::flattened_uniform_type(Type::Enum e) {
 
 std::string YamlGenerator::shader_stage(ShaderStage::Enum e) {
     return ShaderStage::to_str(e);
+}
+
+std::string YamlGenerator::attr_basetype(Type::Enum e) {
+    return Type::type_to_str(e);
 }
 
 std::string YamlGenerator::image_type(ImageType::Enum e) {

--- a/src/shdc/generators/yaml.h
+++ b/src/shdc/generators/yaml.h
@@ -8,6 +8,7 @@ public:
     virtual ErrMsg generate(const GenInput& gen);
 protected:
     virtual std::string shader_stage(refl::ShaderStage::Enum e);
+    virtual std::string attr_basetype(refl::Type::Enum e);
     virtual std::string uniform_type(refl::Type::Enum e);
     virtual std::string flattened_uniform_type(refl::Type::Enum e);
     virtual std::string image_type(refl::ImageType::Enum e);

--- a/src/shdc/types/reflection/type.h
+++ b/src/shdc/types/reflection/type.h
@@ -54,6 +54,7 @@ struct Type {
     bool equals(const Type& other) const;
     std::string type_as_str() const;
     std::string type_as_glsl() const;
+    Type::Enum basetype() const;    // Invalid, Bool, Float, Int, UInt, Struct
     static std::string type_to_str(Type::Enum e);
     static std::string type_to_glsl(Type::Enum e);
     void dump_debug(const std::string& indent) const;
@@ -105,6 +106,47 @@ inline bool Type::equals(const Type& other) const {
 
 inline std::string Type::type_as_str() const {
     return type_to_str(type);
+}
+
+inline Type::Enum Type::basetype() const {
+    switch (type) {
+        case Bool:
+        case Bool2:
+        case Bool3:
+        case Bool4:
+            return Bool;
+        case Int:
+        case Int2:
+        case Int3:
+        case Int4:
+            return Int;
+        case UInt:
+        case UInt2:
+        case UInt3:
+        case UInt4:
+            return UInt;
+        case Float:
+        case Float2:
+        case Float3:
+        case Float4:
+        case Mat2x1:
+        case Mat2x2:
+        case Mat2x3:
+        case Mat2x4:
+        case Mat3x1:
+        case Mat3x2:
+        case Mat3x3:
+        case Mat3x4:
+        case Mat4x1:
+        case Mat4x2:
+        case Mat4x3:
+        case Mat4x4:
+            return Float;
+        case Struct:
+            return Struct;
+        default:
+            return Invalid;
+    }
 }
 
 inline std::string Type::type_to_str(Type::Enum e) {


### PR DESCRIPTION
(also cleans up some redundant semicolons that slipped in during the compute shader update)

Associated sokol-gfx PR: https://github.com/floooh/sokol/pull/1222

TODO:

- [x] generators
    - [x] C
    - [x] Zig
    - [x] Odin
    - [x] C3
    - [x] Nim
    - [x] Rust
    - [x] Jai
    - [x] D
    - [x] Yaml
- [x] changelog