### PR TITLE
fix: incorrect align syntax for Jai

### DIFF
--- a/src/shdc/generators/sokoljai.cc
+++ b/src/shdc/generators/sokoljai.cc
@@ -177,10 +177,11 @@ void SokolJaiGenerator::gen_struct_interior_decl_std430(const GenInput& gen, con
     if (cur_offset < pad_to_size) {
         l("_: [{}]u8;\n", pad_to_size - cur_offset);
     }
+    l("_: void #align {};\n", struc.align);
 }
 
 void SokolJaiGenerator::gen_storage_buffer_decl(const GenInput& gen, const Type& struc) {
-    l_open("{} :: struct #align {} {{\n", struct_name(struc.struct_typename), struc.align);
+    l_open("{} :: struct {{\n", struct_name(struc.struct_typename));
     gen_struct_interior_decl_std430(gen, struc, struc.size);
     l_close("}}\n");
 }


### PR DESCRIPTION
The current shader compiler creates Jai files with #align next to the struct, this doesn't compile and is invalid syntax with the newest Jai beta compiler (and has maybe never compiled?). This PR attempts to fix the situation and I tested that the generated syntax compiles.