### PR TITLE
shdc: Added option to generate a makefile-style dependency file

### DIFF
--- a/src/shdc/args.cc
+++ b/src/shdc/args.cc
@@ -29,6 +29,7 @@ enum {
     OPTION_REFLECTION,
     OPTION_SAVE_INTERMEDIATE_SPIRV,
     OPTION_NO_LOG_CMDLINE,
+    OPTION_DEPENDENCY_FILE,
 };
 
 static const getopt_option_t option_list[] = {
@@ -49,6 +50,7 @@ static const getopt_option_t option_list[] = {
     { "noifdef",            'n', GETOPT_OPTION_TYPE_NO_ARG,     0, OPTION_NOIFDEF,      "obsolete, superseded by --ifdef"},
     { "save-intermediate-spirv", 0, GETOPT_OPTION_TYPE_NO_ARG,  0, OPTION_SAVE_INTERMEDIATE_SPIRV, "save intermediate SPIRV bytecode (for debug inspection)"},
     { "no-log-cmdline",     0,   GETOPT_OPTION_TYPE_NO_ARG,     0, OPTION_NO_LOG_CMDLINE, "don't log the cmdline to the code-generated output file"},
+    { "dependency-file",    0,   GETOPT_OPTION_TYPE_REQUIRED,   0, OPTION_DEPENDENCY_FILE, "generate a makefile-style dependency file at the given path", "[deps file]" },
     GETOPT_OPTIONS_END
 };
 
@@ -260,6 +262,9 @@ Args Args::parse(int argc, const char** argv) {
                 case OPTION_NOIFDEF:
                     // obsolete, but keep for backwards compatibility
                     args.ifdef = false;
+                    break;
+                case OPTION_DEPENDENCY_FILE:
+                    args.dependency_file = ctx.current_opt_arg;
                     break;
                 case OPTION_HELP:
                     print_help_string(ctx);

--- a/src/shdc/args.h
+++ b/src/shdc/args.h
@@ -15,6 +15,7 @@ struct Args {
     std::string input;                  // input file path
     std::string output;                 // output file path
     std::string tmpdir;                 // directory for temporary files
+    std::string dependency_file;        // optional dependency file to generate
     std::string module;                 // optional @module name override
     std::vector<std::string> defines;   // additional preprocessor defines
     uint32_t slang = 0;                 // combined Slang bits

--- a/src/shdc/main.cc
+++ b/src/shdc/main.cc
@@ -34,6 +34,24 @@ int main(int argc, const char** argv) {
         inp.out_error.print(args.error_format);
         return 10;
     }
+    
+    // output source file dependencies
+    if (args.dependency_file.length() > 0) {
+        std::string content;
+        content.append(fmt::format("{}: ", inp.filenames[0].data()));
+        for (size_t i = 1; i < inp.filenames.size(); i++) {
+            content.append(fmt::format(" \\\n  {}", inp.filenames[i].data()));
+        }
+        content.append("\n");
+        FILE* f = fopen(args.dependency_file.c_str(), "w");
+        if (!f) {
+            ErrMsg err = ErrMsg::error(inp.base_path, 0, fmt::format("failed to open dependency output file '{}'", args.dependency_file));
+            err.print(args.error_format);
+            return 10;
+        }
+        fwrite(content.c_str(), content.length(), 1, f);
+        fclose(f);
+    }
 
     // compile source snippets to SPIRV blobs (multiple compilations is necessary
     // because of conditional compilation by target language)


### PR DESCRIPTION
Passing --dependency-file=<filepath> to shdc will produce a file that lists every other file included by @include directives during the processing of the source file. This is useful for build system that track changes to source files and rebuild only the necessary objects.

The produced file looks something like this:
```
code/basic_lit.glsl.h: code/basic_lit.glsl  \
  code/lighting_constants.h \
  code/shader_constants.h
```

The format is based on the file that clang and gcc generate with the options -MD and -MF. The formatting is slightly simpler with only one file per line (which I find is simpler to read anyway).

I have limited cpp experience so it might not be very idiomatic code. I tried to mimic the style of the project though. Let me know if some things need cleanup or should be organised differently!