### PR TITLE
Update for sokol-gfx resource view bindings.

### DIFF
--- a/docs/sokol-shdc.md
+++ b/docs/sokol-shdc.md
@@ -137,7 +137,7 @@ pip = sg_make_pipeline(&(sg_pipeline_desc){
 ```c
 sg_apply_bindings(&(sg_bindings){
     .vertex_buffers[0] = vbuf,
-    .images[IMG_tex] = img,
+    .textures[TEX_tex] = img,
     .samplers[SMP_smp] = smp,
 });
 const vs_params_t vs_params = {
@@ -1018,7 +1018,7 @@ The resource binding slot for texture and sampler uniforms is available
 as code-generated constant:
 
 ```C
-#define IMG_tex (0)
+#define TEX_tex (0)
 #define SMP_smp (0)
 ```
 
@@ -1028,7 +1028,7 @@ and `.samplers[]` arrays:
 ```c
 sg_apply_bindings(&(sg_bindings){
     .vertex_buffers[0] = vbuf,
-    .images[IMG_tex] = img,
+    .textures[TEX_tex] = img,
     .samplers[SMP_smp] = smp,
 });
 ```

--- a/src/shdc/generators/generator.cc
+++ b/src/shdc/generators/generator.cc
@@ -140,12 +140,12 @@ void Generator::gen_bindings_info(const GenInput& gen) {
         cbl("Writeonly: {}\n", simg.writeonly);
         cbl_close();
     }
-    for (const Image& img: gen.refl.bindings.images) {
-        cbl_open("Image '{}':\n", img.name);
-        cbl("Image type: {}\n", image_type(img.type));
-        cbl("Sample type: {}\n", image_sample_type(img.sample_type));
-        cbl("Multisampled: {}\n", img.multisampled);
-        cbl("Bind slot: {} => {}\n", image_bind_slot_name(img), img.sokol_slot);
+    for (const Texture& tex: gen.refl.bindings.textures) {
+        cbl_open("Texture '{}':\n", tex.name);
+        cbl("Image type: {}\n", image_type(tex.type));
+        cbl("Sample type: {}\n", image_sample_type(tex.sample_type));
+        cbl("Multisampled: {}\n", tex.multisampled);
+        cbl("Bind slot: {} => {}\n", texture_bind_slot_name(tex), tex.sokol_slot);
         cbl_close();
     }
     for (const Sampler& smp: gen.refl.bindings.samplers) {
@@ -178,8 +178,8 @@ void Generator::gen_bind_slot_consts(const GenInput& gen) {
     for (const StorageImage& simg: gen.refl.bindings.storage_images) {
         l("{}\n", storage_image_bind_slot_definition(simg));
     }
-    for (const Image& img: gen.refl.bindings.images) {
-        l("{}\n", image_bind_slot_definition(img));
+    for (const Texture& tex: gen.refl.bindings.textures) {
+        l("{}\n", texture_bind_slot_definition(tex));
     }
     for (const Sampler& smp: gen.refl.bindings.samplers) {
         l("{}\n", sampler_bind_slot_definition(smp));
@@ -264,7 +264,7 @@ void Generator::gen_shader_desc_funcs(const GenInput& gen) {
 void Generator::gen_reflection_funcs(const GenInput& gen) {
     for (const auto& prog: gen.refl.progs) {
         gen_attr_slot_refl_func(gen, prog);
-        gen_image_slot_refl_func(gen, prog);
+        gen_texture_slot_refl_func(gen, prog);
         gen_sampler_slot_refl_func(gen, prog);
         gen_uniform_block_slot_refl_func(gen, prog);
         gen_uniform_block_size_refl_func(gen, prog);

--- a/src/shdc/generators/generator.h
+++ b/src/shdc/generators/generator.h
@@ -48,7 +48,7 @@ protected:
 
     // optional, called by gen_reflection_funcs()
     virtual void gen_attr_slot_refl_func(const GenInput& gen, const refl::ProgramReflection& prog) { };
-    virtual void gen_image_slot_refl_func(const GenInput& gen, const refl::ProgramReflection& prog) { };
+    virtual void gen_texture_slot_refl_func(const GenInput& gen, const refl::ProgramReflection& prog) { };
     virtual void gen_sampler_slot_refl_func(const GenInput& gen, const refl::ProgramReflection& progm) { };
     virtual void gen_uniform_block_slot_refl_func(const GenInput& gen, const refl::ProgramReflection& prog) { };
     virtual void gen_uniform_block_size_refl_func(const GenInput& gen, const refl::ProgramReflection& prog) { };
@@ -80,14 +80,14 @@ protected:
 
     virtual std::string struct_name(const std::string& name) { assert(false && "implement me"); return ""; };
     virtual std::string vertex_attr_name(const std::string& prog_name, const refl::StageAttr& attr) { assert(false && "implement me"); return ""; };
-    virtual std::string image_bind_slot_name(const refl::Image& img) { assert(false && "implement me"); return ""; };
+    virtual std::string texture_bind_slot_name(const refl::Texture& tex) { assert(false && "implement me"); return ""; };
     virtual std::string sampler_bind_slot_name(const refl::Sampler& smp) { assert(false && "implement me"); return ""; };
     virtual std::string uniform_block_bind_slot_name(const refl::UniformBlock& ub) { assert(false && "implement me"); return ""; };
     virtual std::string storage_buffer_bind_slot_name(const refl::StorageBuffer& sbuf) { assert(false && "implement me"); return ""; };
     virtual std::string storage_image_bind_slot_name(const refl::StorageImage& simg) { assert(false && "implement me"); return ""; };
 
     virtual std::string vertex_attr_definition(const std::string& prog_name, const refl::StageAttr& attr) { assert(false && "implement me"); return ""; };
-    virtual std::string image_bind_slot_definition(const refl::Image& img) { assert(false && "implement me"); return ""; };
+    virtual std::string texture_bind_slot_definition(const refl::Texture& img) { assert(false && "implement me"); return ""; };
     virtual std::string sampler_bind_slot_definition(const refl::Sampler& smp) { assert(false && "implement me"); return ""; };
     virtual std::string uniform_block_bind_slot_definition(const refl::UniformBlock& ub) { assert(false && "implement me"); return ""; };
     virtual std::string storage_buffer_bind_slot_definition(const refl::StorageBuffer& sbuf) { assert(false && "implement me"); return ""; };

--- a/src/shdc/generators/sokolc.cc
+++ b/src/shdc/generators/sokolc.cc
@@ -378,20 +378,20 @@ void SokolCGenerator::gen_shader_desc_func(const GenInput& gen, const ProgramRef
                     }
                 }
             }
-            for (int img_index = 0; img_index < Bindings::MaxImages; img_index++) {
-                const Image* img = prog.bindings.find_image_by_sokol_slot(img_index);
-                if (img) {
-                    const std::string in = fmt::format("desc.images[{}]", img_index);
-                    l("{}.stage = {};\n", in, shader_stage(img->stage));
-                    l("{}.image_type = {};\n", in, image_type(img->type));
-                    l("{}.sample_type = {};\n", in, image_sample_type(img->sample_type));
-                    l("{}.multisampled = {};\n", in, img->multisampled ? "true" : "false");
+            for (int tex_index = 0; tex_index < Bindings::MaxTextures; tex_index++) {
+                const Texture* tex = prog.bindings.find_texture_by_sokol_slot(tex_index);
+                if (tex) {
+                    const std::string tn = fmt::format("desc.textures[{}]", tex_index);
+                    l("{}.stage = {};\n", tn, shader_stage(tex->stage));
+                    l("{}.image_type = {};\n", tn, image_type(tex->type));
+                    l("{}.sample_type = {};\n", tn, image_sample_type(tex->sample_type));
+                    l("{}.multisampled = {};\n", tn, tex->multisampled ? "true" : "false");
                     if (Slang::is_hlsl(slang)) {
-                        l("{}.hlsl_register_t_n = {};\n", in, img->hlsl_register_t_n);
+                        l("{}.hlsl_register_t_n = {};\n", tn, tex->hlsl_register_t_n);
                     } else if (Slang::is_msl(slang)) {
-                        l("{}.msl_texture_n = {};\n", in, img->msl_texture_n);
+                        l("{}.msl_texture_n = {};\n", tn, tex->msl_texture_n);
                     } else if (Slang::is_wgsl(slang)) {
-                        l("{}.wgsl_group1_binding_n = {};\n", in, img->wgsl_group1_binding_n);
+                        l("{}.wgsl_group1_binding_n = {};\n", tn, tex->wgsl_group1_binding_n);
                     }
                 }
             }
@@ -410,15 +410,15 @@ void SokolCGenerator::gen_shader_desc_func(const GenInput& gen, const ProgramRef
                     }
                 }
             }
-            for (int img_smp_index = 0; img_smp_index < Bindings::MaxImageSamplers; img_smp_index++) {
-                const ImageSampler* img_smp = prog.bindings.find_image_sampler_by_sokol_slot(img_smp_index);
-                if (img_smp) {
-                    const std::string isn = fmt::format("desc.image_sampler_pairs[{}]", img_smp_index);
-                    l("{}.stage = {};\n", isn, shader_stage(img_smp->stage));
-                    l("{}.image_slot = {};\n", isn, prog.bindings.find_image_by_name(img_smp->image_name)->sokol_slot);
-                    l("{}.sampler_slot = {};\n", isn, prog.bindings.find_sampler_by_name(img_smp->sampler_name)->sokol_slot);
+            for (int tex_smp_index = 0; tex_smp_index < Bindings::MaxTextureSamplers; tex_smp_index++) {
+                const TextureSampler* tex_smp = prog.bindings.find_texture_sampler_by_sokol_slot(tex_smp_index);
+                if (tex_smp) {
+                    const std::string tsn = fmt::format("desc.texture_sampler_pairs[{}]", tex_smp_index);
+                    l("{}.stage = {};\n", tsn, shader_stage(tex_smp->stage));
+                    l("{}.texture_slot = {};\n", tsn, prog.bindings.find_texture_by_name(tex_smp->texture_name)->sokol_slot);
+                    l("{}.sampler_slot = {};\n", tsn, prog.bindings.find_sampler_by_name(tex_smp->sampler_name)->sokol_slot);
                     if (Slang::is_glsl(slang)) {
-                        l("{}.glsl_name = \"{}\";\n", isn, img_smp->name);
+                        l("{}.glsl_name = \"{}\";\n", tsn, tex_smp->name);
                     }
                 }
             }
@@ -449,13 +449,13 @@ void SokolCGenerator::gen_attr_slot_refl_func(const GenInput& gen, const Program
     l_close("}}\n");
 }
 
-void SokolCGenerator::gen_image_slot_refl_func(const GenInput& gen, const ProgramReflection& prog) {
-    l_open("{}int {}{}_image_slot(const char* img_name) {{\n", func_prefix, mod_prefix, prog.name);
-    l("(void)img_name;\n");
-    for (const Image& img: prog.bindings.images) {
-        if (img.sokol_slot >= 0) {
-            l_open("if (0 == strcmp(img_name, \"{}\")) {{\n", img.name);
-            l("return {};\n", img.sokol_slot);
+void SokolCGenerator::gen_texture_slot_refl_func(const GenInput& gen, const ProgramReflection& prog) {
+    l_open("{}int {}{}_texture_slot(const char* tex_name) {{\n", func_prefix, mod_prefix, prog.name);
+    l("(void)tex_name;\n");
+    for (const Texture& tex: prog.bindings.textures) {
+        if (tex.sokol_slot >= 0) {
+            l_open("if (0 == strcmp(tex_name, \"{}\")) {{\n", tex.name);
+            l("return {};\n", tex.sokol_slot);
             l_close("}}\n");
         }
     }
@@ -766,8 +766,8 @@ std::string SokolCGenerator::vertex_attr_name(const std::string& prog_name, cons
     return fmt::format("ATTR_{}{}_{}", mod_prefix, prog_name, attr.name);
 }
 
-std::string SokolCGenerator::image_bind_slot_name(const Image& img) {
-    return fmt::format("IMG_{}{}", mod_prefix, img.name);
+std::string SokolCGenerator::texture_bind_slot_name(const Texture& tex) {
+    return fmt::format("TEX_{}{}", mod_prefix, tex.name);
 }
 
 std::string SokolCGenerator::sampler_bind_slot_name(const Sampler& smp) {
@@ -790,8 +790,8 @@ std::string SokolCGenerator::vertex_attr_definition(const std::string& prog_name
     return fmt::format("#define {} ({})", vertex_attr_name(prog_name, attr), attr.slot);
 }
 
-std::string SokolCGenerator::image_bind_slot_definition(const Image& img) {
-    return fmt::format("#define {} ({})", image_bind_slot_name(img), img.sokol_slot);
+std::string SokolCGenerator::texture_bind_slot_definition(const Texture& tex) {
+    return fmt::format("#define {} ({})", texture_bind_slot_name(tex), tex.sokol_slot);
 }
 
 std::string SokolCGenerator::sampler_bind_slot_definition(const Sampler& smp) {

--- a/src/shdc/generators/sokolc.h
+++ b/src/shdc/generators/sokolc.h
@@ -19,7 +19,7 @@ protected:
     virtual void gen_stb_impl_end(const GenInput& gen);
     virtual void gen_shader_desc_func(const GenInput& gen, const refl::ProgramReflection& prog);
     virtual void gen_attr_slot_refl_func(const GenInput& gen, const refl::ProgramReflection& prog);
-    virtual void gen_image_slot_refl_func(const GenInput& gen, const refl::ProgramReflection& prog);
+    virtual void gen_texture_slot_refl_func(const GenInput& gen, const refl::ProgramReflection& prog);
     virtual void gen_sampler_slot_refl_func(const GenInput& gen, const refl::ProgramReflection& progm);
     virtual void gen_uniform_block_slot_refl_func(const GenInput& gen, const refl::ProgramReflection& prog);
     virtual void gen_uniform_block_size_refl_func(const GenInput& gen, const refl::ProgramReflection& prog);
@@ -45,13 +45,13 @@ protected:
     virtual std::string backend(Slang::Enum e);
     virtual std::string struct_name(const std::string& name);
     virtual std::string vertex_attr_name(const std::string& prog_name, const refl::StageAttr& attr);
-    virtual std::string image_bind_slot_name(const refl::Image& img);
+    virtual std::string texture_bind_slot_name(const refl::Texture& tex);
     virtual std::string sampler_bind_slot_name(const refl::Sampler& smp);
     virtual std::string uniform_block_bind_slot_name(const refl::UniformBlock& ub);
     virtual std::string storage_buffer_bind_slot_name(const refl::StorageBuffer& sbuf);
     virtual std::string storage_image_bind_slot_name(const refl::StorageImage& simg);
     virtual std::string vertex_attr_definition(const std::string& prog_name, const refl::StageAttr& attr);
-    virtual std::string image_bind_slot_definition(const refl::Image& img);
+    virtual std::string texture_bind_slot_definition(const refl::Texture& tex);
     virtual std::string sampler_bind_slot_definition(const refl::Sampler& smp);
     virtual std::string uniform_block_bind_slot_definition(const refl::UniformBlock& ub);
     virtual std::string storage_buffer_bind_slot_definition(const refl::StorageBuffer& sbuf);

--- a/src/shdc/generators/sokolc3.cc
+++ b/src/shdc/generators/sokolc3.cc
@@ -317,20 +317,20 @@ void SokolC3Generator::gen_shader_desc_func(const GenInput& gen, const ProgramRe
                     }
                 }
             }
-            for (int img_index = 0; img_index < Bindings::MaxImages; img_index++) {
-                const Image* img = prog.bindings.find_image_by_sokol_slot(img_index);
-                if (img) {
-                    const std::string in = fmt::format("desc.images[{}]", img_index);
-                    l("{}.stage = {};\n", in, shader_stage(img->stage));
-                    l("{}.multisampled = {};\n", in, img->multisampled ? "true" : "false");
-                    l("{}.image_type = {};\n", in, image_type(img->type));
-                    l("{}.sample_type = {};\n", in, image_sample_type(img->sample_type));
+            for (int tex_index = 0; tex_index < Bindings::MaxTextures; tex_index++) {
+                const Texture* tex = prog.bindings.find_texture_by_sokol_slot(tex_index);
+                if (tex) {
+                    const std::string tn = fmt::format("desc.textures[{}]", tex_index);
+                    l("{}.stage = {};\n", tn, shader_stage(tex->stage));
+                    l("{}.multisampled = {};\n", tn, tex->multisampled ? "true" : "false");
+                    l("{}.image_type = {};\n", tn, image_type(tex->type));
+                    l("{}.sample_type = {};\n", tn, image_sample_type(tex->sample_type));
                     if (Slang::is_hlsl(slang)) {
-                        l("{}.hlsl_register_t_n = {};\n", in, img->hlsl_register_t_n);
+                        l("{}.hlsl_register_t_n = {};\n", tn, tex->hlsl_register_t_n);
                     } else if (Slang::is_msl(slang)) {
-                        l("{}.msl_texture_n = {};\n", in, img->msl_texture_n);
+                        l("{}.msl_texture_n = {};\n", tn, tex->msl_texture_n);
                     } else if (Slang::is_wgsl(slang)) {
-                        l("{}.wgsl_group1_binding_n = {};\n", in, img->wgsl_group1_binding_n);
+                        l("{}.wgsl_group1_binding_n = {};\n", tn, tex->wgsl_group1_binding_n);
                     }
                 }
             }
@@ -349,15 +349,15 @@ void SokolC3Generator::gen_shader_desc_func(const GenInput& gen, const ProgramRe
                     }
                 }
             }
-            for (int img_smp_index = 0; img_smp_index < Bindings::MaxImageSamplers; img_smp_index++) {
-                const ImageSampler* img_smp = prog.bindings.find_image_sampler_by_sokol_slot(img_smp_index);
-                if (img_smp) {
-                    const std::string isn = fmt::format("desc.image_sampler_pairs[{}]", img_smp_index);
-                    l("{}.stage = {};\n", isn, shader_stage(img_smp->stage));
-                    l("{}.image_slot = {};\n", isn, prog.bindings.find_image_by_name(img_smp->image_name)->sokol_slot);
-                    l("{}.sampler_slot = {};\n", isn, prog.bindings.find_sampler_by_name(img_smp->sampler_name)->sokol_slot);
+            for (int tex_smp_index = 0; tex_smp_index < Bindings::MaxTextureSamplers; tex_smp_index++) {
+                const TextureSampler* tex_smp = prog.bindings.find_texture_sampler_by_sokol_slot(tex_smp_index);
+                if (tex_smp) {
+                    const std::string tsn = fmt::format("desc.texture_sampler_pairs[{}]", tex_smp_index);
+                    l("{}.stage = {};\n", tsn, shader_stage(tex_smp->stage));
+                    l("{}.texture_slot = {};\n", tsn, prog.bindings.find_texture_by_name(tex_smp->texture_name)->sokol_slot);
+                    l("{}.sampler_slot = {};\n", tsn, prog.bindings.find_sampler_by_name(tex_smp->sampler_name)->sokol_slot);
                     if (Slang::is_glsl(slang)) {
-                        l("{}.glsl_name = \"{}\";\n", isn, img_smp->name);
+                        l("{}.glsl_name = \"{}\";\n", tsn, tex_smp->name);
                     }
                 }
             }
@@ -540,8 +540,8 @@ std::string SokolC3Generator::vertex_attr_name(const std::string& prog_name, con
     return pystring::upper(fmt::format("ATTR_{}_{}", prog_name, attr.name));
 }
 
-std::string SokolC3Generator::image_bind_slot_name(const Image& img) {
-    return pystring::upper(fmt::format("IMG_{}", img.name));
+std::string SokolC3Generator::texture_bind_slot_name(const Texture& tex) {
+    return pystring::upper(fmt::format("TEX_{}", tex.name));
 }
 
 std::string SokolC3Generator::sampler_bind_slot_name(const Sampler& smp) {
@@ -564,8 +564,8 @@ std::string SokolC3Generator::vertex_attr_definition(const std::string& prog_nam
     return fmt::format("const int {} = {};", vertex_attr_name(prog_name, attr), attr.slot);
 }
 
-std::string SokolC3Generator::image_bind_slot_definition(const Image& img) {
-    return fmt::format("const int {} = {};", image_bind_slot_name(img), img.sokol_slot);
+std::string SokolC3Generator::texture_bind_slot_definition(const Texture& tex) {
+    return fmt::format("const int {} = {};", texture_bind_slot_name(tex), tex.sokol_slot);
 }
 
 std::string SokolC3Generator::sampler_bind_slot_definition(const Sampler& smp) {

--- a/src/shdc/generators/sokolc3.cc
+++ b/src/shdc/generators/sokolc3.cc
@@ -311,7 +311,7 @@ void SokolC3Generator::gen_shader_desc_func(const GenInput& gen, const ProgramRe
                     } else if (Slang::is_msl(slang)) {
                         l("{}.msl_texture_n = {};\n", sin, simg->msl_texture_n);
                     } else if (Slang::is_wgsl(slang)) {
-                        l("{}.wgsl_group2_binding_n = {};\n", sin, simg->wgsl_group2_binding_n);
+                        l("{}.wgsl_group1_binding_n = {};\n", sin, simg->wgsl_group1_binding_n);
                     } else if (Slang::is_glsl(slang)) {
                         l("{}.glsl_binding_n = {};\n", sin, simg->glsl_binding_n);
                     }

--- a/src/shdc/generators/sokolc3.h
+++ b/src/shdc/generators/sokolc3.h
@@ -31,13 +31,13 @@ protected:
     virtual std::string backend(Slang::Enum e);
     virtual std::string struct_name(const std::string& name);
     virtual std::string vertex_attr_name(const std::string& prog_name, const refl::StageAttr& attr);
-    virtual std::string image_bind_slot_name(const refl::Image& img);
+    virtual std::string texture_bind_slot_name(const refl::Texture& tex);
     virtual std::string sampler_bind_slot_name(const refl::Sampler& smp);
     virtual std::string uniform_block_bind_slot_name(const refl::UniformBlock& ub);
     virtual std::string storage_buffer_bind_slot_name(const refl::StorageBuffer& sbuf);
     virtual std::string storage_image_bind_slot_name(const refl::StorageImage& simg);
     virtual std::string vertex_attr_definition(const std::string& prog_name, const refl::StageAttr& attr);
-    virtual std::string image_bind_slot_definition(const refl::Image& img);
+    virtual std::string texture_bind_slot_definition(const refl::Texture& tex);
     virtual std::string sampler_bind_slot_definition(const refl::Sampler& smp);
     virtual std::string uniform_block_bind_slot_definition(const refl::UniformBlock& ub);
     virtual std::string storage_buffer_bind_slot_definition(const refl::StorageBuffer& sbuf);

--- a/src/shdc/generators/sokold.cc
+++ b/src/shdc/generators/sokold.cc
@@ -320,7 +320,7 @@ void SokolDGenerator::gen_shader_desc_func(const GenInput& gen, const ProgramRef
                     } else if (Slang::is_msl(slang)) {
                         l("{}.msl_texture_n = {};\n", sin, simg->msl_texture_n);
                     } else if (Slang::is_wgsl(slang)) {
-                        l("{}.wgsl_group2_binding_n = {};\n", sin, simg->wgsl_group2_binding_n);
+                        l("{}.wgsl_group1_binding_n = {};\n", sin, simg->wgsl_group1_binding_n);
                     } else if (Slang::is_glsl(slang)) {
                         l("{}.glsl_binding_n = {};\n", sin, simg->glsl_binding_n);
                     }

--- a/src/shdc/generators/sokold.cc
+++ b/src/shdc/generators/sokold.cc
@@ -326,20 +326,20 @@ void SokolDGenerator::gen_shader_desc_func(const GenInput& gen, const ProgramRef
                     }
                 }
             }
-            for (int img_index = 0; img_index < Bindings::MaxImages; img_index++) {
-                const Image* img = prog.bindings.find_image_by_sokol_slot(img_index);
-                if (img) {
-                    const std::string in = fmt::format("desc.images[{}]", img_index);
-                    l("{}.stage = {};\n", in, shader_stage(img->stage));
-                    l("{}.multisampled = {};\n", in, img->multisampled ? "true" : "false");
-                    l("{}.image_type = {};\n", in, image_type(img->type));
-                    l("{}.sample_type = {};\n", in, image_sample_type(img->sample_type));
+            for (int tex_index = 0; tex_index < Bindings::MaxTextures; tex_index++) {
+                const Texture* tex = prog.bindings.find_texture_by_sokol_slot(tex_index);
+                if (tex) {
+                    const std::string tn = fmt::format("desc.textures[{}]", tex_index);
+                    l("{}.stage = {};\n", tn, shader_stage(tex->stage));
+                    l("{}.multisampled = {};\n", tn, tex->multisampled ? "true" : "false");
+                    l("{}.image_type = {};\n", tn, image_type(tex->type));
+                    l("{}.sample_type = {};\n", tn, image_sample_type(tex->sample_type));
                     if (Slang::is_hlsl(slang)) {
-                        l("{}.hlsl_register_t_n = {};\n", in, img->hlsl_register_t_n);
+                        l("{}.hlsl_register_t_n = {};\n", tn, tex->hlsl_register_t_n);
                     } else if (Slang::is_msl(slang)) {
-                        l("{}.msl_texture_n = {};\n", in, img->msl_texture_n);
+                        l("{}.msl_texture_n = {};\n", tn, tex->msl_texture_n);
                     } else if (Slang::is_wgsl(slang)) {
-                        l("{}.wgsl_group1_binding_n = {};\n", in, img->wgsl_group1_binding_n);
+                        l("{}.wgsl_group1_binding_n = {};\n", tn, tex->wgsl_group1_binding_n);
                     }
                 }
             }
@@ -358,15 +358,15 @@ void SokolDGenerator::gen_shader_desc_func(const GenInput& gen, const ProgramRef
                     }
                 }
             }
-            for (int img_smp_index = 0; img_smp_index < Bindings::MaxImageSamplers; img_smp_index++) {
-                const ImageSampler* img_smp = prog.bindings.find_image_sampler_by_sokol_slot(img_smp_index);
-                if (img_smp) {
-                    const std::string isn = fmt::format("desc.image_sampler_pairs[{}]", img_smp_index);
-                    l("{}.stage = {};\n", isn, shader_stage(img_smp->stage));
-                    l("{}.image_slot = {};\n", isn, prog.bindings.find_image_by_name(img_smp->image_name)->sokol_slot);
-                    l("{}.sampler_slot = {};\n", isn, prog.bindings.find_sampler_by_name(img_smp->sampler_name)->sokol_slot);
+            for (int tex_smp_index = 0; tex_smp_index < Bindings::MaxTextureSamplers; tex_smp_index++) {
+                const TextureSampler* tex_smp = prog.bindings.find_texture_sampler_by_sokol_slot(tex_smp_index);
+                if (tex_smp) {
+                    const std::string tsn = fmt::format("desc.texture_sampler_pairs[{}]", tex_smp_index);
+                    l("{}.stage = {};\n", tsn, shader_stage(tex_smp->stage));
+                    l("{}.texture_slot = {};\n", tsn, prog.bindings.find_texture_by_name(tex_smp->texture_name)->sokol_slot);
+                    l("{}.sampler_slot = {};\n", tsn, prog.bindings.find_sampler_by_name(tex_smp->sampler_name)->sokol_slot);
                     if (Slang::is_glsl(slang)) {
-                        l("{}.glsl_name = \"{}\";\n", isn, img_smp->name);
+                        l("{}.glsl_name = \"{}\";\n", tsn, tex_smp->name);
                     }
                 }
             }
@@ -543,8 +543,8 @@ std::string SokolDGenerator::vertex_attr_name(const std::string& prog_name, cons
     return pystring::upper(fmt::format("ATTR_{}_{}", prog_name, attr.name));
 }
 
-std::string SokolDGenerator::image_bind_slot_name(const Image& img) {
-    return pystring::upper(fmt::format("IMG_{}", img.name));
+std::string SokolDGenerator::texture_bind_slot_name(const Texture& tex) {
+    return pystring::upper(fmt::format("TEX_{}", tex.name));
 }
 
 std::string SokolDGenerator::sampler_bind_slot_name(const Sampler& smp) {
@@ -571,8 +571,8 @@ std::string SokolDGenerator::vertex_attr_definition(const std::string& prog_name
     return const_def(vertex_attr_name(prog_name, attr), attr.slot);
 }
 
-std::string SokolDGenerator::image_bind_slot_definition(const Image& img) {
-    return const_def(image_bind_slot_name(img), img.sokol_slot);
+std::string SokolDGenerator::texture_bind_slot_definition(const Texture& tex) {
+    return const_def(texture_bind_slot_name(tex), tex.sokol_slot);
 }
 
 std::string SokolDGenerator::sampler_bind_slot_definition(const Sampler& smp) {

--- a/src/shdc/generators/sokold.h
+++ b/src/shdc/generators/sokold.h
@@ -31,13 +31,13 @@ protected:
     virtual std::string backend(Slang::Enum e);
     virtual std::string struct_name(const std::string& name);
     virtual std::string vertex_attr_name(const std::string& prog_name, const refl::StageAttr& attr);
-    virtual std::string image_bind_slot_name(const refl::Image& img);
+    virtual std::string texture_bind_slot_name(const refl::Texture& tex);
     virtual std::string sampler_bind_slot_name(const refl::Sampler& smp);
     virtual std::string uniform_block_bind_slot_name(const refl::UniformBlock& ub);
     virtual std::string storage_buffer_bind_slot_name(const refl::StorageBuffer& sbuf);
     virtual std::string storage_image_bind_slot_name(const refl::StorageImage& simg);
     virtual std::string vertex_attr_definition(const std::string& prog_name, const refl::StageAttr& attr);
-    virtual std::string image_bind_slot_definition(const refl::Image& img);
+    virtual std::string texture_bind_slot_definition(const refl::Texture& tex);
     virtual std::string sampler_bind_slot_definition(const refl::Sampler& smp);
     virtual std::string uniform_block_bind_slot_definition(const refl::UniformBlock& ub);
     virtual std::string storage_buffer_bind_slot_definition(const refl::StorageBuffer& sbuf);

--- a/src/shdc/generators/sokoljai.cc
+++ b/src/shdc/generators/sokoljai.cc
@@ -311,20 +311,20 @@ void SokolJaiGenerator::gen_shader_desc_func(const GenInput& gen, const ProgramR
                     }
                 }
             }
-            for (int img_index = 0; img_index < Bindings::MaxImages; img_index++) {
-                const Image* img = prog.bindings.find_image_by_sokol_slot(img_index);
-                if (img) {
-                    const std::string in = fmt::format("desc.images[{}]", img_index);
-                    l("{}.stage = {};\n", in, shader_stage(img->stage));
-                    l("{}.multisampled = {};\n", in, img->multisampled ? "true" : "false");
-                    l("{}.image_type = {};\n", in, image_type(img->type));
-                    l("{}.sample_type = {};\n", in, image_sample_type(img->sample_type));
+            for (int tex_index = 0; tex_index < Bindings::MaxTextures; tex_index++) {
+                const Texture* tex = prog.bindings.find_texture_by_sokol_slot(tex_index);
+                if (tex) {
+                    const std::string tn = fmt::format("desc.textures[{}]", tex_index);
+                    l("{}.stage = {};\n", tn, shader_stage(tex->stage));
+                    l("{}.multisampled = {};\n", tn, tex->multisampled ? "true" : "false");
+                    l("{}.image_type = {};\n", tn, image_type(tex->type));
+                    l("{}.sample_type = {};\n", tn, image_sample_type(tex->sample_type));
                     if (Slang::is_hlsl(slang)) {
-                        l("{}.hlsl_register_t_n = {};\n", in, img->hlsl_register_t_n);
+                        l("{}.hlsl_register_t_n = {};\n", tn, tex->hlsl_register_t_n);
                     } else if (Slang::is_msl(slang)) {
-                        l("{}.msl_texture_n = {};\n", in, img->msl_texture_n);
+                        l("{}.msl_texture_n = {};\n", tn, tex->msl_texture_n);
                     } else if (Slang::is_wgsl(slang)) {
-                        l("{}.wgsl_group1_binding_n = {};\n", in, img->wgsl_group1_binding_n);
+                        l("{}.wgsl_group1_binding_n = {};\n", tn, tex->wgsl_group1_binding_n);
                     }
                 }
             }
@@ -343,15 +343,15 @@ void SokolJaiGenerator::gen_shader_desc_func(const GenInput& gen, const ProgramR
                     }
                 }
             }
-            for (int img_smp_index = 0; img_smp_index < Bindings::MaxImageSamplers; img_smp_index++) {
-                const ImageSampler* img_smp = prog.bindings.find_image_sampler_by_sokol_slot(img_smp_index);
-                if (img_smp) {
-                    const std::string isn = fmt::format("desc.image_sampler_pairs[{}]", img_smp_index);
-                    l("{}.stage = {};\n", isn, shader_stage(img_smp->stage));
-                    l("{}.image_slot = {};\n", isn, prog.bindings.find_image_by_name(img_smp->image_name)->sokol_slot);
-                    l("{}.sampler_slot = {};\n", isn, prog.bindings.find_sampler_by_name(img_smp->sampler_name)->sokol_slot);
+            for (int tex_smp_index = 0; tex_smp_index < Bindings::MaxTextureSamplers; tex_smp_index++) {
+                const TextureSampler* tex_smp = prog.bindings.find_texture_sampler_by_sokol_slot(tex_smp_index);
+                if (tex_smp) {
+                    const std::string tsn = fmt::format("desc.texture_sampler_pairs[{}]", tex_smp_index);
+                    l("{}.stage = {};\n", tsn, shader_stage(tex_smp->stage));
+                    l("{}.texture_slot = {};\n", tsn, prog.bindings.find_texture_by_name(tex_smp->texture_name)->sokol_slot);
+                    l("{}.sampler_slot = {};\n", tsn, prog.bindings.find_sampler_by_name(tex_smp->sampler_name)->sokol_slot);
                     if (Slang::is_glsl(slang)) {
-                        l("{}.glsl_name = \"{}\";\n", isn, img_smp->name);
+                        l("{}.glsl_name = \"{}\";\n", tsn, tex_smp->name);
                     }
                 }
             }
@@ -534,8 +534,8 @@ std::string SokolJaiGenerator::vertex_attr_name(const std::string& prog_name, co
     return fmt::format("ATTR_{}_{}", prog_name, attr.name);
 }
 
-std::string SokolJaiGenerator::image_bind_slot_name(const Image& img) {
-    return fmt::format("IMG_{}", img.name);
+std::string SokolJaiGenerator::texture_bind_slot_name(const Texture& tex) {
+    return fmt::format("TEX_{}", tex.name);
 }
 
 std::string SokolJaiGenerator::sampler_bind_slot_name(const Sampler& smp) {
@@ -558,8 +558,8 @@ std::string SokolJaiGenerator::vertex_attr_definition(const std::string& prog_na
     return fmt::format("{} :: {};", vertex_attr_name(prog_name, attr), attr.slot);
 }
 
-std::string SokolJaiGenerator::image_bind_slot_definition(const Image& img) {
-    return fmt::format("{} :: {};", image_bind_slot_name(img), img.sokol_slot);
+std::string SokolJaiGenerator::texture_bind_slot_definition(const Texture& tex) {
+    return fmt::format("{} :: {};", texture_bind_slot_name(tex), tex.sokol_slot);
 }
 
 std::string SokolJaiGenerator::sampler_bind_slot_definition(const Sampler& smp) {

--- a/src/shdc/generators/sokoljai.cc
+++ b/src/shdc/generators/sokoljai.cc
@@ -305,7 +305,7 @@ void SokolJaiGenerator::gen_shader_desc_func(const GenInput& gen, const ProgramR
                     } else if (Slang::is_msl(slang)) {
                         l("{}.msl_texture_n = {};\n", sin, simg->msl_texture_n);
                     } else if (Slang::is_wgsl(slang)) {
-                        l("{}.wgsl_group2_binding_n = {};\n", sin, simg->wgsl_group2_binding_n);
+                        l("{}.wgsl_group1_binding_n = {};\n", sin, simg->wgsl_group1_binding_n);
                     } else if (Slang::is_glsl(slang)) {
                         l("{}.glsl_binding_n = {};\n", sin, simg->glsl_binding_n);
                     }

--- a/src/shdc/generators/sokoljai.h
+++ b/src/shdc/generators/sokoljai.h
@@ -31,13 +31,13 @@ protected:
     virtual std::string backend(Slang::Enum e);
     virtual std::string struct_name(const std::string& name);
     virtual std::string vertex_attr_name(const std::string& prog_name, const refl::StageAttr& attr);
-    virtual std::string image_bind_slot_name(const refl::Image& img);
+    virtual std::string texture_bind_slot_name(const refl::Texture& tex);
     virtual std::string sampler_bind_slot_name(const refl::Sampler& smp);
     virtual std::string uniform_block_bind_slot_name(const refl::UniformBlock& ub);
     virtual std::string storage_buffer_bind_slot_name(const refl::StorageBuffer& sbuf);
     virtual std::string storage_image_bind_slot_name(const refl::StorageImage& simg);
     virtual std::string vertex_attr_definition(const std::string& prog_name, const refl::StageAttr& attr);
-    virtual std::string image_bind_slot_definition(const refl::Image& img);
+    virtual std::string texture_bind_slot_definition(const refl::Texture& tex);
     virtual std::string sampler_bind_slot_definition(const refl::Sampler& smp);
     virtual std::string uniform_block_bind_slot_definition(const refl::UniformBlock& ub);
     virtual std::string storage_buffer_bind_slot_definition(const refl::StorageBuffer& sbuf);

--- a/src/shdc/generators/sokolnim.cc
+++ b/src/shdc/generators/sokolnim.cc
@@ -387,7 +387,7 @@ void SokolNimGenerator::gen_shader_desc_func(const GenInput& gen, const ProgramR
                     } else if (Slang::is_msl(slang)) {
                         l("{}.mslTextureN = {}\n", sin, simg->msl_texture_n);
                     } else if (Slang::is_wgsl(slang)) {
-                        l("{}.wgslGroup2BindingN = {}\n", sin, simg->wgsl_group2_binding_n);
+                        l("{}.wgslGroup1BindingN = {}\n", sin, simg->wgsl_group1_binding_n);
                     } else if (Slang::is_glsl(slang)) {
                         l("{}.glslBindingN = {}\n", sin, simg->glsl_binding_n);
                     }

--- a/src/shdc/generators/sokolnim.cc
+++ b/src/shdc/generators/sokolnim.cc
@@ -393,20 +393,20 @@ void SokolNimGenerator::gen_shader_desc_func(const GenInput& gen, const ProgramR
                     }
                 }
             }
-            for (int img_index = 0; img_index < Bindings::MaxImages; img_index++) {
-                const Image* img = prog.bindings.find_image_by_sokol_slot(img_index);
-                if (img) {
-                    const std::string in = fmt::format("result.images[{}]", img_index);
-                    l("{}.stage = {}\n", in, shader_stage(img->stage));
-                    l("{}.multisampled = {}\n", in, img->multisampled ? "true" : "false");
-                    l("{}.imageType = {}\n", in, image_type(img->type));
-                    l("{}.sampleType = {}\n", in, image_sample_type(img->sample_type));
+            for (int tex_index = 0; tex_index < Bindings::MaxTextures; tex_index++) {
+                const Texture* tex = prog.bindings.find_texture_by_sokol_slot(tex_index);
+                if (tex) {
+                    const std::string tn = fmt::format("result.textures[{}]", tex_index);
+                    l("{}.stage = {}\n", tn, shader_stage(tex->stage));
+                    l("{}.multisampled = {}\n", tn, tex->multisampled ? "true" : "false");
+                    l("{}.imageType = {}\n", tn, image_type(tex->type));
+                    l("{}.sampleType = {}\n", tn, image_sample_type(tex->sample_type));
                     if (Slang::is_hlsl(slang)) {
-                        l("{}.hlslRegisterTN = {}\n", in, img->hlsl_register_t_n);
+                        l("{}.hlslRegisterTN = {}\n", tn, tex->hlsl_register_t_n);
                     } else if (Slang::is_msl(slang)) {
-                        l("{}.mslTextureN = {}\n", in, img->msl_texture_n);
+                        l("{}.mslTextureN = {}\n", tn, tex->msl_texture_n);
                     } else if (Slang::is_wgsl(slang)) {
-                        l("{}.wgslGroup1BindingN = {}\n", in, img->wgsl_group1_binding_n);
+                        l("{}.wgslGroup1BindingN = {}\n", tn, tex->wgsl_group1_binding_n);
                     }
                 }
             }
@@ -425,15 +425,15 @@ void SokolNimGenerator::gen_shader_desc_func(const GenInput& gen, const ProgramR
                     }
                 }
             }
-            for (int img_smp_index = 0; img_smp_index < Bindings::MaxImageSamplers; img_smp_index++) {
-                const ImageSampler* img_smp = prog.bindings.find_image_sampler_by_sokol_slot(img_smp_index);
-                if (img_smp) {
-                    const std::string isn = fmt::format("result.imageSamplerPairs[{}]", img_smp_index);
-                    l("{}.stage = {}\n", isn, shader_stage(img_smp->stage));
-                    l("{}.imageSlot = {}\n", isn, prog.bindings.find_image_by_name(img_smp->image_name)->sokol_slot);
-                    l("{}.samplerSlot = {}\n", isn, prog.bindings.find_sampler_by_name(img_smp->sampler_name)->sokol_slot);
+            for (int tex_smp_index = 0; tex_smp_index < Bindings::MaxTextureSamplers; tex_smp_index++) {
+                const TextureSampler* tex_smp = prog.bindings.find_texture_sampler_by_sokol_slot(tex_smp_index);
+                if (tex_smp) {
+                    const std::string tsn = fmt::format("result.textureSamplerPairs[{}]", tex_smp_index);
+                    l("{}.stage = {}\n", tsn, shader_stage(tex_smp->stage));
+                    l("{}.textureSlot = {}\n", tsn, prog.bindings.find_texture_by_name(tex_smp->texture_name)->sokol_slot);
+                    l("{}.samplerSlot = {}\n", tsn, prog.bindings.find_sampler_by_name(tex_smp->sampler_name)->sokol_slot);
                     if (Slang::is_glsl(slang)) {
-                        l("{}.glslName = \"{}\"\n", isn, img_smp->name);
+                        l("{}.glslName = \"{}\"\n", tsn, tex_smp->name);
                     }
                 }
             }
@@ -616,8 +616,8 @@ std::string SokolNimGenerator::vertex_attr_name(const std::string& prog_name, co
     return to_camel_case(fmt::format("ATTR_{}_{}", prog_name, attr.name));
 }
 
-std::string SokolNimGenerator::image_bind_slot_name(const Image& img) {
-    return to_camel_case(fmt::format("IMG_{}", img.name));
+std::string SokolNimGenerator::texture_bind_slot_name(const Texture& tex) {
+    return to_camel_case(fmt::format("TEX_{}", tex.name));
 }
 
 std::string SokolNimGenerator::sampler_bind_slot_name(const Sampler& smp) {
@@ -640,8 +640,8 @@ std::string SokolNimGenerator::vertex_attr_definition(const std::string& prog_na
     return fmt::format("const {}* = {}", vertex_attr_name(prog_name, attr), attr.slot);
 }
 
-std::string SokolNimGenerator::image_bind_slot_definition(const Image& img) {
-    return fmt::format("const {}* = {}", image_bind_slot_name(img), img.sokol_slot);
+std::string SokolNimGenerator::texture_bind_slot_definition(const Texture& tex) {
+    return fmt::format("const {}* = {}", texture_bind_slot_name(tex), tex.sokol_slot);
 }
 
 std::string SokolNimGenerator::sampler_bind_slot_definition(const Sampler& smp) {

--- a/src/shdc/generators/sokolnim.h
+++ b/src/shdc/generators/sokolnim.h
@@ -33,13 +33,13 @@ protected:
     virtual std::string backend(Slang::Enum e);
     virtual std::string struct_name(const std::string& name);
     virtual std::string vertex_attr_name(const std::string& prog_name, const refl::StageAttr& attr);
-    virtual std::string image_bind_slot_name(const refl::Image& img);
+    virtual std::string texture_bind_slot_name(const refl::Texture& tex);
     virtual std::string sampler_bind_slot_name(const refl::Sampler& smp);
     virtual std::string uniform_block_bind_slot_name(const refl::UniformBlock& ub);
     virtual std::string storage_buffer_bind_slot_name(const refl::StorageBuffer& sbuf);
     virtual std::string storage_image_bind_slot_name(const refl::StorageImage& simg);
     virtual std::string vertex_attr_definition(const std::string& prog_name, const refl::StageAttr& attr);
-    virtual std::string image_bind_slot_definition(const refl::Image& img);
+    virtual std::string texture_bind_slot_definition(const refl::Texture& tex);
     virtual std::string sampler_bind_slot_definition(const refl::Sampler& smp);
     virtual std::string uniform_block_bind_slot_definition(const refl::UniformBlock& ub);
     virtual std::string storage_buffer_bind_slot_definition(const refl::StorageBuffer& sbuf);

--- a/src/shdc/generators/sokolodin.cc
+++ b/src/shdc/generators/sokolodin.cc
@@ -320,20 +320,20 @@ void SokolOdinGenerator::gen_shader_desc_func(const GenInput& gen, const Program
                     }
                 }
             }
-            for (int img_index = 0; img_index < Bindings::MaxImages; img_index++) {
-                const Image* img = prog.bindings.find_image_by_sokol_slot(img_index);
-                if (img) {
-                    const std::string in = fmt::format("desc.images[{}]", img_index);
-                    l("{}.stage = {}\n", in, shader_stage(img->stage));
-                    l("{}.multisampled = {}\n", in, img->multisampled ? "true" : "false");
-                    l("{}.image_type = {}\n", in, image_type(img->type));
-                    l("{}.sample_type = {}\n", in, image_sample_type(img->sample_type));
+            for (int tex_index = 0; tex_index < Bindings::MaxTextures; tex_index++) {
+                const Texture* tex = prog.bindings.find_texture_by_sokol_slot(tex_index);
+                if (tex) {
+                    const std::string tn = fmt::format("desc.textures[{}]", tex_index);
+                    l("{}.stage = {}\n", tn, shader_stage(tex->stage));
+                    l("{}.multisampled = {}\n", tn, tex->multisampled ? "true" : "false");
+                    l("{}.image_type = {}\n", tn, image_type(tex->type));
+                    l("{}.sample_type = {}\n", tn, image_sample_type(tex->sample_type));
                     if (Slang::is_hlsl(slang)) {
-                        l("{}.hlsl_register_t_n = {}\n", in, img->hlsl_register_t_n);
+                        l("{}.hlsl_register_t_n = {}\n", tn, tex->hlsl_register_t_n);
                     } else if (Slang::is_msl(slang)) {
-                        l("{}.msl_texture_n = {}\n", in, img->msl_texture_n);
+                        l("{}.msl_texture_n = {}\n", tn, tex->msl_texture_n);
                     } else if (Slang::is_wgsl(slang)) {
-                        l("{}.wgsl_group1_binding_n = {}\n", in, img->wgsl_group1_binding_n);
+                        l("{}.wgsl_group1_binding_n = {}\n", tn, tex->wgsl_group1_binding_n);
                     }
                 }
             }
@@ -352,15 +352,15 @@ void SokolOdinGenerator::gen_shader_desc_func(const GenInput& gen, const Program
                     }
                 }
             }
-            for (int img_smp_index = 0; img_smp_index < Bindings::MaxImageSamplers; img_smp_index++) {
-                const ImageSampler* img_smp = prog.bindings.find_image_sampler_by_sokol_slot(img_smp_index);
-                if (img_smp) {
-                    const std::string isn = fmt::format("desc.image_sampler_pairs[{}]", img_smp_index);
-                    l("{}.stage = {}\n", isn, shader_stage(img_smp->stage));
-                    l("{}.image_slot = {}\n", isn, prog.bindings.find_image_by_name(img_smp->image_name)->sokol_slot);
-                    l("{}.sampler_slot = {}\n", isn, prog.bindings.find_sampler_by_name(img_smp->sampler_name)->sokol_slot);
+            for (int tex_smp_index = 0; tex_smp_index < Bindings::MaxTextureSamplers; tex_smp_index++) {
+                const TextureSampler* tex_smp = prog.bindings.find_texture_sampler_by_sokol_slot(tex_smp_index);
+                if (tex_smp) {
+                    const std::string tsn = fmt::format("desc.texture_sampler_pairs[{}]", tex_smp_index);
+                    l("{}.stage = {}\n", tsn, shader_stage(tex_smp->stage));
+                    l("{}.texture_slot = {}\n", tsn, prog.bindings.find_texture_by_name(tex_smp->texture_name)->sokol_slot);
+                    l("{}.sampler_slot = {}\n", tsn, prog.bindings.find_sampler_by_name(tex_smp->sampler_name)->sokol_slot);
                     if (Slang::is_glsl(slang)) {
-                        l("{}.glsl_name = \"{}\"\n", isn, img_smp->name);
+                        l("{}.glsl_name = \"{}\"\n", tsn, tex_smp->name);
                     }
                 }
             }
@@ -385,12 +385,12 @@ void SokolOdinGenerator::gen_attr_slot_refl_func(const GenInput& gen, const Prog
     l_close("}}\n");
 }
 
-void SokolOdinGenerator::gen_image_slot_refl_func(const GenInput& gen, const ProgramReflection& prog) {
-    l_open("{}{}_image_slot :: proc (img_name: string) -> int {{\n", mod_prefix, prog.name);
-    for (const Image& img: prog.bindings.images) {
-        if (img.sokol_slot >= 0) {
-            l_open("if img_name == \"{}\" {{\n", img.name);
-            l("return {}\n", img.sokol_slot);
+void SokolOdinGenerator::gen_texture_slot_refl_func(const GenInput& gen, const ProgramReflection& prog) {
+    l_open("{}{}_texture_slot :: proc (tex_name: string) -> int {{\n", mod_prefix, prog.name);
+    for (const Texture& tex: prog.bindings.textures) {
+        if (tex.sokol_slot >= 0) {
+            l_open("if tex_name == \"{}\" {{\n", tex.name);
+            l("return {}\n", tex.sokol_slot);
             l_close("}}\n");
         }
     }
@@ -673,8 +673,8 @@ std::string SokolOdinGenerator::vertex_attr_name(const std::string& prog_name, c
     return fmt::format("ATTR_{}{}_{}", mod_prefix, prog_name, attr.name);
 }
 
-std::string SokolOdinGenerator::image_bind_slot_name(const Image& img) {
-    return fmt::format("IMG_{}{}", mod_prefix, img.name);
+std::string SokolOdinGenerator::texture_bind_slot_name(const Texture& tex) {
+    return fmt::format("TEX_{}{}", mod_prefix, tex.name);
 }
 
 std::string SokolOdinGenerator::sampler_bind_slot_name(const Sampler& smp) {
@@ -697,8 +697,8 @@ std::string SokolOdinGenerator::vertex_attr_definition(const std::string& prog_n
     return fmt::format("{} :: {}", vertex_attr_name(prog_name, attr), attr.slot);
 }
 
-std::string SokolOdinGenerator::image_bind_slot_definition(const Image& img) {
-    return fmt::format("{} :: {}", image_bind_slot_name(img), img.sokol_slot);
+std::string SokolOdinGenerator::texture_bind_slot_definition(const Texture& tex) {
+    return fmt::format("{} :: {}", texture_bind_slot_name(tex), tex.sokol_slot);
 }
 
 std::string SokolOdinGenerator::sampler_bind_slot_definition(const Sampler& smp) {

--- a/src/shdc/generators/sokolodin.cc
+++ b/src/shdc/generators/sokolodin.cc
@@ -314,7 +314,7 @@ void SokolOdinGenerator::gen_shader_desc_func(const GenInput& gen, const Program
                     } else if (Slang::is_msl(slang)) {
                         l("{}.msl_texture_n = {}\n", sin, simg->msl_texture_n);
                     } else if (Slang::is_wgsl(slang)) {
-                        l("{}.wgsl_group2_binding_n = {}\n", sin, simg->wgsl_group2_binding_n);
+                        l("{}.wgsl_group1_binding_n = {}\n", sin, simg->wgsl_group1_binding_n);
                     } else if (Slang::is_glsl(slang)) {
                         l("{}.glsl_binding_n = {}\n", sin, simg->glsl_binding_n);
                     }

--- a/src/shdc/generators/sokolodin.h
+++ b/src/shdc/generators/sokolodin.h
@@ -16,7 +16,7 @@ protected:
     virtual void gen_shader_array_end(const GenInput& gen);
     virtual void gen_shader_desc_func(const GenInput& gen, const refl::ProgramReflection& prog);
     virtual void gen_attr_slot_refl_func(const GenInput& gen, const refl::ProgramReflection& prog);
-    virtual void gen_image_slot_refl_func(const GenInput& gen, const refl::ProgramReflection& prog);
+    virtual void gen_texture_slot_refl_func(const GenInput& gen, const refl::ProgramReflection& prog);
     virtual void gen_sampler_slot_refl_func(const GenInput& gen, const refl::ProgramReflection& progm);
     virtual void gen_uniform_block_slot_refl_func(const GenInput& gen, const refl::ProgramReflection& prog);
     virtual void gen_uniform_block_size_refl_func(const GenInput& gen, const refl::ProgramReflection& prog);
@@ -42,13 +42,13 @@ protected:
     virtual std::string backend(Slang::Enum e);
     virtual std::string struct_name(const std::string& name);
     virtual std::string vertex_attr_name(const std::string& prog_name, const refl::StageAttr& attr);
-    virtual std::string image_bind_slot_name(const refl::Image& img);
+    virtual std::string texture_bind_slot_name(const refl::Texture& tex);
     virtual std::string sampler_bind_slot_name(const refl::Sampler& smp);
     virtual std::string uniform_block_bind_slot_name(const refl::UniformBlock& ub);
     virtual std::string storage_buffer_bind_slot_name(const refl::StorageBuffer& sbuf);
     virtual std::string storage_image_bind_slot_name(const refl::StorageImage& simg);
     virtual std::string vertex_attr_definition(const std::string& prog_name, const refl::StageAttr& attr);
-    virtual std::string image_bind_slot_definition(const refl::Image& img);
+    virtual std::string texture_bind_slot_definition(const refl::Texture& tex);
     virtual std::string sampler_bind_slot_definition(const refl::Sampler& smp);
     virtual std::string uniform_block_bind_slot_definition(const refl::UniformBlock& ub);
     virtual std::string storage_buffer_bind_slot_definition(const refl::StorageBuffer& sbuf);

--- a/src/shdc/generators/sokolrust.cc
+++ b/src/shdc/generators/sokolrust.cc
@@ -320,7 +320,7 @@ void SokolRustGenerator::gen_shader_desc_func(const GenInput& gen, const Program
                     } else if (Slang::is_msl(slang)) {
                         l("{}.msl_texture_n = {};\n", sin, simg->msl_texture_n);
                     } else if (Slang::is_wgsl(slang)) {
-                        l("{}.wgsl_group2_binding_n = {};\n", sin, simg->wgsl_group2_binding_n);
+                        l("{}.wgsl_group1_binding_n = {};\n", sin, simg->wgsl_group1_binding_n);
                     } else if (Slang::is_glsl(slang)) {
                         l("{}.glsl_binding_n = {};\n", sin, simg->glsl_binding_n);
                     }

--- a/src/shdc/generators/sokolrust.cc
+++ b/src/shdc/generators/sokolrust.cc
@@ -326,20 +326,20 @@ void SokolRustGenerator::gen_shader_desc_func(const GenInput& gen, const Program
                     }
                 }
             }
-            for (int img_index = 0; img_index < Bindings::MaxImages; img_index++) {
-                const Image* img = prog.bindings.find_image_by_sokol_slot(img_index);
-                if (img) {
-                    const std::string in = fmt::format("desc.images[{}]", img_index);
-                    l("{}.stage = {};\n", in, shader_stage(img->stage));
-                    l("{}.multisampled = {};\n", in, img->multisampled ? "true" : "false");
-                    l("{}.image_type = {};\n", in, image_type(img->type));
-                    l("{}.sample_type = {};\n", in, image_sample_type(img->sample_type));
+            for (int tex_index = 0; tex_index < Bindings::MaxTextures; tex_index++) {
+                const Texture* tex = prog.bindings.find_texture_by_sokol_slot(tex_index);
+                if (tex) {
+                    const std::string tn = fmt::format("desc.textures[{}]", tex_index);
+                    l("{}.stage = {};\n", tn, shader_stage(tex->stage));
+                    l("{}.multisampled = {};\n", tn, tex->multisampled ? "true" : "false");
+                    l("{}.image_type = {};\n", tn, image_type(tex->type));
+                    l("{}.sample_type = {};\n", tn, image_sample_type(tex->sample_type));
                     if (Slang::is_hlsl(slang)) {
-                        l("{}.hlsl_register_t_n = {};\n", in, img->hlsl_register_t_n);
+                        l("{}.hlsl_register_t_n = {};\n", tn, tex->hlsl_register_t_n);
                     } else if (Slang::is_msl(slang)) {
-                        l("{}.msl_texture_n = {};\n", in, img->msl_texture_n);
+                        l("{}.msl_texture_n = {};\n", tn, tex->msl_texture_n);
                     } else if (Slang::is_wgsl(slang)) {
-                        l("{}.wgsl_group1_binding_n = {};\n", in, img->wgsl_group1_binding_n);
+                        l("{}.wgsl_group1_binding_n = {};\n", tn, tex->wgsl_group1_binding_n);
                     }
                 }
             }
@@ -358,15 +358,15 @@ void SokolRustGenerator::gen_shader_desc_func(const GenInput& gen, const Program
                     }
                 }
             }
-            for (int img_smp_index = 0; img_smp_index < Bindings::MaxImageSamplers; img_smp_index++) {
-                const ImageSampler* img_smp = prog.bindings.find_image_sampler_by_sokol_slot(img_smp_index);
-                if (img_smp) {
-                    const std::string isn = fmt::format("desc.image_sampler_pairs[{}]", img_smp_index);
-                    l("{}.stage = {};\n", isn, shader_stage(img_smp->stage));
-                    l("{}.image_slot = {};\n", isn, prog.bindings.find_image_by_name(img_smp->image_name)->sokol_slot);
-                    l("{}.sampler_slot = {};\n", isn, prog.bindings.find_sampler_by_name(img_smp->sampler_name)->sokol_slot);
+            for (int tex_smp_index = 0; tex_smp_index < Bindings::MaxTextureSamplers; tex_smp_index++) {
+                const TextureSampler* tex_smp = prog.bindings.find_texture_sampler_by_sokol_slot(tex_smp_index);
+                if (tex_smp) {
+                    const std::string tsn = fmt::format("desc.texture_sampler_pairs[{}]", tex_smp_index);
+                    l("{}.stage = {};\n", tsn, shader_stage(tex_smp->stage));
+                    l("{}.texture_slot = {};\n", tsn, prog.bindings.find_texture_by_name(tex_smp->texture_name)->sokol_slot);
+                    l("{}.sampler_slot = {};\n", tsn, prog.bindings.find_sampler_by_name(tex_smp->sampler_name)->sokol_slot);
                     if (Slang::is_glsl(slang)) {
-                        l("{}.glsl_name = c\"{}\".as_ptr();\n", isn, img_smp->name);
+                        l("{}.glsl_name = c\"{}\".as_ptr();\n", tsn, tex_smp->name);
                     }
                 }
             }
@@ -550,8 +550,8 @@ std::string SokolRustGenerator::vertex_attr_name(const std::string& prog_name, c
     return pystring::upper(fmt::format("ATTR_{}_{}", prog_name, attr.name));
 }
 
-std::string SokolRustGenerator::image_bind_slot_name(const Image& img) {
-    return pystring::upper(fmt::format("IMG_{}", img.name));
+std::string SokolRustGenerator::texture_bind_slot_name(const Texture& tex) {
+    return pystring::upper(fmt::format("TEX_{}", tex.name));
 }
 
 std::string SokolRustGenerator::sampler_bind_slot_name(const Sampler& smp) {
@@ -574,8 +574,8 @@ std::string SokolRustGenerator::vertex_attr_definition(const std::string& prog_n
     return fmt::format("pub const {}: usize = {};", vertex_attr_name(prog_name, attr), attr.slot);
 }
 
-std::string SokolRustGenerator::image_bind_slot_definition(const Image& img) {
-    return fmt::format("pub const {}: usize = {};", image_bind_slot_name(img), img.sokol_slot);
+std::string SokolRustGenerator::texture_bind_slot_definition(const Texture& tex) {
+    return fmt::format("pub const {}: usize = {};", texture_bind_slot_name(tex), tex.sokol_slot);
 }
 
 std::string SokolRustGenerator::sampler_bind_slot_definition(const Sampler& smp) {

--- a/src/shdc/generators/sokolrust.h
+++ b/src/shdc/generators/sokolrust.h
@@ -31,13 +31,13 @@ protected:
     virtual std::string backend(Slang::Enum e);
     virtual std::string struct_name(const std::string& name);
     virtual std::string vertex_attr_name(const std::string& prog_name, const refl::StageAttr& attr);
-    virtual std::string image_bind_slot_name(const refl::Image& img);
+    virtual std::string texture_bind_slot_name(const refl::Texture& tex);
     virtual std::string sampler_bind_slot_name(const refl::Sampler& smp);
     virtual std::string uniform_block_bind_slot_name(const refl::UniformBlock& ub);
     virtual std::string storage_buffer_bind_slot_name(const refl::StorageBuffer& sbuf);
     virtual std::string storage_image_bind_slot_name(const refl::StorageImage& simg);
     virtual std::string vertex_attr_definition(const std::string& prog_name, const refl::StageAttr& attr);
-    virtual std::string image_bind_slot_definition(const refl::Image& img);
+    virtual std::string texture_bind_slot_definition(const refl::Texture& tex);
     virtual std::string sampler_bind_slot_definition(const refl::Sampler& smp);
     virtual std::string uniform_block_bind_slot_definition(const refl::UniformBlock& ub);
     virtual std::string storage_buffer_bind_slot_definition(const refl::StorageBuffer& sbuf);

--- a/src/shdc/generators/sokolzig.cc
+++ b/src/shdc/generators/sokolzig.cc
@@ -318,7 +318,7 @@ void SokolZigGenerator::gen_shader_desc_func(const GenInput& gen, const ProgramR
                     } else if (Slang::is_msl(slang)) {
                         l("{}.msl_texture_n = {};\n", sin, simg->msl_texture_n);
                     } else if (Slang::is_wgsl(slang)) {
-                        l("{}.wgsl_group2_binding_n = {};\n", sin, simg->wgsl_group2_binding_n);
+                        l("{}.wgsl_group1_binding_n = {};\n", sin, simg->wgsl_group1_binding_n);
                     } else if (Slang::is_glsl(slang)) {
                         l("{}.glsl_binding_n = {};\n", sin, simg->glsl_binding_n);
                     }

--- a/src/shdc/generators/sokolzig.h
+++ b/src/shdc/generators/sokolzig.h
@@ -14,7 +14,7 @@ protected:
     virtual void gen_shader_array_end(const GenInput& gen);
     virtual void gen_shader_desc_func(const GenInput& gen, const refl::ProgramReflection& prog);
     virtual void gen_attr_slot_refl_func(const GenInput& gen, const refl::ProgramReflection& prog);
-    virtual void gen_image_slot_refl_func(const GenInput& gen, const refl::ProgramReflection& prog);
+    virtual void gen_texture_slot_refl_func(const GenInput& gen, const refl::ProgramReflection& prog);
     virtual void gen_sampler_slot_refl_func(const GenInput& gen, const refl::ProgramReflection& progm);
     virtual void gen_uniform_block_slot_refl_func(const GenInput& gen, const refl::ProgramReflection& prog);
     virtual void gen_uniform_block_size_refl_func(const GenInput& gen, const refl::ProgramReflection& prog);
@@ -40,13 +40,13 @@ protected:
     virtual std::string backend(Slang::Enum e);
     virtual std::string struct_name(const std::string& name);
     virtual std::string vertex_attr_name(const std::string& prog_name, const refl::StageAttr& attr);
-    virtual std::string image_bind_slot_name(const refl::Image& img);
+    virtual std::string texture_bind_slot_name(const refl::Texture& tex);
     virtual std::string sampler_bind_slot_name(const refl::Sampler& smp);
     virtual std::string uniform_block_bind_slot_name(const refl::UniformBlock& ub);
     virtual std::string storage_buffer_bind_slot_name(const refl::StorageBuffer& sbuf);
     virtual std::string storage_image_bind_slot_name(const refl::StorageImage& simg);
     virtual std::string vertex_attr_definition(const std::string& prog_name, const refl::StageAttr& attr);
-    virtual std::string image_bind_slot_definition(const refl::Image& img);
+    virtual std::string texture_bind_slot_definition(const refl::Texture& tex);
     virtual std::string sampler_bind_slot_definition(const refl::Sampler& smp);
     virtual std::string uniform_block_bind_slot_definition(const refl::UniformBlock& ub);
     virtual std::string storage_buffer_bind_slot_definition(const refl::StorageBuffer& sbuf);

--- a/src/shdc/generators/yaml.cc
+++ b/src/shdc/generators/yaml.cc
@@ -91,10 +91,10 @@ ErrMsg YamlGenerator::generate(const GenInput& gen) {
                     }
                     l_close();
                 }
-                if (prog.bindings.images.size() > 0) {
-                    l_open("images:\n");
-                    for (const auto& image: prog.bindings.images) {
-                        gen_image(image, slang);
+                if (prog.bindings.textures.size() > 0) {
+                    l_open("textures:\n");
+                    for (const auto& texture: prog.bindings.textures) {
+                        gen_texture(texture, slang);
                     }
                     l_close();
                 }
@@ -105,10 +105,10 @@ ErrMsg YamlGenerator::generate(const GenInput& gen) {
                     }
                     l_close();
                 }
-                if (prog.bindings.image_samplers.size() > 0) {
-                    l_open("image_sampler_pairs:\n");
-                    for (const auto& image_sampler: prog.bindings.image_samplers) {
-                        gen_image_sampler(image_sampler, slang);
+                if (prog.bindings.texture_samplers.size() > 0) {
+                    l_open("texture_sampler_pairs:\n");
+                    for (const auto& texture_sampler: prog.bindings.texture_samplers) {
+                        gen_texture_sampler(texture_sampler, slang);
                     }
                     l_close();
                 }
@@ -246,20 +246,20 @@ void YamlGenerator::gen_storage_image(const StorageImage& simg, Slang::Enum slan
     l_close();
 }
 
-void YamlGenerator::gen_image(const Image& img, Slang::Enum slang) {
+void YamlGenerator::gen_texture(const Texture& tex, Slang::Enum slang) {
     l_open("-\n");
-    l("slot: {}\n", img.sokol_slot);
-    l("stage: {}\n", shader_stage(img.stage));
-    l("name: {}\n", img.name);
-    l("multisampled: {}\n", img.multisampled);
-    l("type: {}\n", image_type(img.type));
-    l("sample_type: {}\n", image_sample_type(img.sample_type));
+    l("slot: {}\n", tex.sokol_slot);
+    l("stage: {}\n", shader_stage(tex.stage));
+    l("name: {}\n", tex.name);
+    l("multisampled: {}\n", tex.multisampled);
+    l("type: {}\n", image_type(tex.type));
+    l("sample_type: {}\n", image_sample_type(tex.sample_type));
     if (Slang::is_hlsl(slang)) {
-        l("hlsl_register_t_n: {}\n", img.hlsl_register_t_n);
+        l("hlsl_register_t_n: {}\n", tex.hlsl_register_t_n);
     } else if (Slang::is_msl(slang)) {
-        l("msl_texture_n: {}\n", img.msl_texture_n);
+        l("msl_texture_n: {}\n", tex.msl_texture_n);
     } else if (Slang::is_wgsl(slang)) {
-        l("wgsl_group1_binding_n: {}\n", img.wgsl_group1_binding_n);
+        l("wgsl_group1_binding_n: {}\n", tex.wgsl_group1_binding_n);
     }
     l_close();
 }
@@ -280,15 +280,15 @@ void YamlGenerator::gen_sampler(const Sampler& smp, Slang::Enum slang) {
     l_close();
 }
 
-void YamlGenerator::gen_image_sampler(const ImageSampler& img_smp, Slang::Enum slang) {
+void YamlGenerator::gen_texture_sampler(const TextureSampler& tex_smp, Slang::Enum slang) {
     l_open("-\n");
-    l("slot: {}\n", img_smp.sokol_slot);
-    l("stage: {}\n", shader_stage(img_smp.stage));
-    l("name: {}\n", img_smp.name);
-    l("image_name: {}\n", img_smp.image_name);
-    l("sampler_name: {}\n", img_smp.sampler_name);
+    l("slot: {}\n", tex_smp.sokol_slot);
+    l("stage: {}\n", shader_stage(tex_smp.stage));
+    l("name: {}\n", tex_smp.name);
+    l("texture_name: {}\n", tex_smp.texture_name);
+    l("sampler_name: {}\n", tex_smp.sampler_name);
     if (Slang::is_glsl(slang)) {
-        l("glsl_name: {}\n", img_smp.name);
+        l("glsl_name: {}\n", tex_smp.name);
     }
     l_close();
 }

--- a/src/shdc/generators/yaml.cc
+++ b/src/shdc/generators/yaml.cc
@@ -239,7 +239,7 @@ void YamlGenerator::gen_storage_image(const StorageImage& simg, Slang::Enum slan
     } else if (Slang::is_msl(slang)) {
         l("msl_texture_n: {}\n", simg.msl_texture_n);
     } else if (Slang::is_wgsl(slang)) {
-        l("wgsl_group2_binding_n: {}\n", simg.wgsl_group2_binding_n);
+        l("wgsl_group1_binding_n: {}\n", simg.wgsl_group1_binding_n);
     } else if (Slang::is_glsl(slang)) {
         l("glsl_binding_n: {}\n", simg.glsl_binding_n);
     }

--- a/src/shdc/generators/yaml.h
+++ b/src/shdc/generators/yaml.h
@@ -21,9 +21,9 @@ private:
     void gen_uniform_block_refl(const refl::UniformBlock& ub);
     void gen_storage_buffer(const refl::StorageBuffer& sbuf, Slang::Enum slang);
     void gen_storage_image(const refl::StorageImage& simg, Slang::Enum slang);
-    void gen_image(const refl::Image& img, Slang::Enum slang);
+    void gen_texture(const refl::Texture& tex, Slang::Enum slang);
     void gen_sampler(const refl::Sampler& smp, Slang::Enum slang);
-    void gen_image_sampler(const refl::ImageSampler& img_smp, Slang::Enum slang);
+    void gen_texture_sampler(const refl::TextureSampler& tex_smp, Slang::Enum slang);
 };
 
 } // namespace

--- a/src/shdc/reflection.cc
+++ b/src/shdc/reflection.cc
@@ -380,7 +380,7 @@ StageReflection Reflection::parse_snippet_reflection(const Compiler& compiler, c
         refl_simg.sokol_slot = inp.find_simg_slot(refl_simg.name);
         refl_simg.hlsl_register_u_n = slot + Bindings::base_slot(Slang::HLSL5, refl.stage, res_type);
         refl_simg.msl_texture_n = slot + Bindings::base_slot(Slang::METAL_SIM, refl.stage, res_type);
-        refl_simg.wgsl_group2_binding_n = slot + Bindings::base_slot(Slang::WGSL, refl.stage, res_type);
+        refl_simg.wgsl_group1_binding_n = slot + Bindings::base_slot(Slang::WGSL, refl.stage, res_type);
         refl_simg.glsl_binding_n = refl_simg.sokol_slot;
         refl_simg.writeonly = mask.get(spv::DecorationNonReadable);
         refl_simg.type = spirtype_to_image_type(spir_type);
@@ -696,58 +696,54 @@ ErrMsg Reflection::validate_program_bindings(const Bindings& bindings) {
         }
     }
     {
-        std::array<std::string, Bindings::MaxStorageBuffers> sbuf_slots;
-        std::array<std::string, Bindings::MaxStorageImages> simg_slots;
+        std::array<std::string, Bindings::MaxViews> view_slots;
         for (const auto& sbuf: bindings.storage_buffers) {
             const int slot = sbuf.sokol_slot;
-            if ((slot < 0) || (slot >= Bindings::MaxStorageBuffers)) {
-                return ErrMsg::error(fmt::format("binding {} out of range for storage buffer '{}' (must be 0..{})",
+            if ((slot < 0) || (slot >= Bindings::MaxViews)) {
+                return ErrMsg::error(fmt::format("binding {} out of range for resource '{}' (must be 0..{})",
                     slot,
                     sbuf.name,
-                    Bindings::MaxStorageBuffers - 1));
+                    Bindings::MaxViews - 1));
             }
-            if (!sbuf_slots[slot].empty()) {
-                return ErrMsg::error(fmt::format("storage buffer '{}' and '{}' cannot use the same binding {}",
-                    sbuf_slots[slot],
+            if (!view_slots[slot].empty()) {
+                return ErrMsg::error(fmt::format("resources '{}' and '{}' cannot use the same binding {}",
+                    view_slots[slot],
                     sbuf.name,
                     slot));
             }
-            sbuf_slots[slot] = sbuf.name;
+            view_slots[slot] = sbuf.name;
         }
         for (const auto& simg: bindings.storage_images) {
             const int slot = simg.sokol_slot;
-            if ((slot < 0) || (slot >= Bindings::MaxStorageImages)) {
-                return ErrMsg::error(fmt::format("binding {} out of range for storage image '{}' (must be 0..{})",
+            if ((slot < 0) || (slot >= Bindings::MaxViews)) {
+                return ErrMsg::error(fmt::format("binding {} out of range for resource '{}' (must be 0..{})",
                     slot,
                     simg.name,
-                    Bindings::MaxStorageImages - 1));
+                    Bindings::MaxViews - 1));
             }
-            if (!simg_slots[slot].empty()) {
-                return ErrMsg::error(fmt::format("storage image '{}' and '{}' cannot use the same binding {}",
-                    simg_slots[slot],
+            if (!view_slots[slot].empty()) {
+                return ErrMsg::error(fmt::format("resources '{}' and '{}' cannot use the same binding {}",
+                    view_slots[slot],
                     simg.name,
                     slot));
             }
-            simg_slots[slot] = simg.name;
+            view_slots[slot] = simg.name;
         }
-    }
-    {
-        std::array<std::string, Bindings::MaxTextures> tex_slots;
         for (const auto& tex: bindings.textures) {
             const int slot = tex.sokol_slot;
-            if ((slot < 0) || (slot > Bindings::MaxTextures)) {
-                return ErrMsg::error(fmt::format("binding {} out of range for texture '{}' (must be 0..{})",
+            if ((slot < 0) || (slot > Bindings::MaxViews)) {
+                return ErrMsg::error(fmt::format("binding {} out of range for resource '{}' (must be 0..{})",
                     slot,
                     tex.name,
-                    Bindings::MaxTextures - 1));
+                    Bindings::MaxViews - 1));
             }
-            if (!tex_slots[slot].empty()) {
-                return ErrMsg::error(fmt::format("textures '{}' and '{}' cannot use the same binding {}",
-                    tex_slots[slot],
+            if (!view_slots[slot].empty()) {
+                return ErrMsg::error(fmt::format("resources '{}' and '{}' cannot use the same binding {}",
+                    view_slots[slot],
                     tex.name,
                     slot));
             }
-            tex_slots[slot] = tex.name;
+            view_slots[slot] = tex.name;
         }
     }
     {

--- a/src/shdc/spirvcross.cc
+++ b/src/shdc/spirvcross.cc
@@ -45,18 +45,18 @@ static void fix_bind_slots(Compiler& compiler, Snippet::Type snippet_type, Slang
         }
     }
 
-    // combined image samplers
+    // combined texture samplers
     {
-        uint32_t binding = Bindings::base_slot(slang, stage, Bindings::Type::IMAGE_SAMPLER);
+        uint32_t binding = Bindings::base_slot(slang, stage, Bindings::Type::TEXTURE_SAMPLER);
         for (const Resource& res: shader_resources.sampled_images) {
             compiler.set_decoration(res.id, spv::DecorationDescriptorSet, 0);
             compiler.set_decoration(res.id, spv::DecorationBinding, binding++);
         }
     }
 
-    // separate images
+    // separate textures
     {
-        uint32_t binding = Bindings::base_slot(slang, stage, Bindings::Type::IMAGE);
+        uint32_t binding = Bindings::base_slot(slang, stage, Bindings::Type::TEXTURE);
         for (const Resource& res: shader_resources.separate_images) {
             compiler.set_decoration(res.id, spv::DecorationDescriptorSet, 0);
             compiler.set_decoration(res.id, spv::DecorationBinding, binding++);
@@ -150,9 +150,9 @@ static void wgsl_patch_bind_slots(Compiler& compiler, Snippet::Type snippet_type
         }
     }
 
-    // separate images
+    // separate textures
     {
-        uint32_t binding = Bindings::base_slot(slang, stage, Bindings::Type::IMAGE);
+        uint32_t binding = Bindings::base_slot(slang, stage, Bindings::Type::TEXTURE);
         for (const Resource& res: shader_resources.separate_images) {
             uint32_t out_offset = 0;
             if (compiler.get_binary_offset_for_decoration(res.id, spv::DecorationDescriptorSet, out_offset)) {

--- a/src/shdc/types/reflection/storage_image.h
+++ b/src/shdc/types/reflection/storage_image.h
@@ -13,7 +13,7 @@ struct StorageImage {
     int sokol_slot = -1;
     int hlsl_register_u_n = -1;
     int msl_texture_n = -1;
-    int wgsl_group2_binding_n = -1;
+    int wgsl_group1_binding_n = -1;
     int glsl_binding_n = -1;
     std::string name;   // shortcut for struct_info.name
     bool writeonly;
@@ -39,7 +39,7 @@ inline void StorageImage::dump_debug(const std::string& indent) const {
     fmt::print(stderr, "{}sokol_slot: {}\n", indent2, sokol_slot);
     fmt::print(stderr, "{}hlsl_register_u_n: {}\n", indent2, hlsl_register_u_n);
     fmt::print(stderr, "{}msl_texture_n: {}\n", indent2, msl_texture_n);
-    fmt::print(stderr, "{}wgsl_group2_binding_n: {}\n", indent2, wgsl_group2_binding_n);
+    fmt::print(stderr, "{}wgsl_group1_binding_n: {}\n", indent2, wgsl_group1_binding_n);
     fmt::print(stderr, "{}name: {}\n", indent2, name);
     fmt::print(stderr, "{}type: {}\n", indent2, ImageType::to_str(type));
     fmt::print(stderr, "{}access_format: {}\n", indent2, StoragePixelFormat::to_str(access_format));

--- a/src/shdc/types/reflection/texture.h
+++ b/src/shdc/types/reflection/texture.h
@@ -7,7 +7,7 @@
 
 namespace shdc::refl {
 
-struct Image {
+struct Texture {
     ShaderStage::Enum stage = ShaderStage::Invalid;
     int sokol_slot = -1;
     int hlsl_register_t_n = -1;
@@ -18,11 +18,11 @@ struct Image {
     ImageSampleType::Enum sample_type = ImageSampleType::INVALID;
     bool multisampled = false;
 
-    bool equals(const Image& other) const;
+    bool equals(const Texture& other) const;
     void dump_debug(const std::string& indent) const;
 };
 
-inline bool Image::equals(const Image& other) const {
+inline bool Texture::equals(const Texture& other) const {
     return (stage == other.stage)
         && (sokol_slot == other.sokol_slot)
         && (name == other.name)
@@ -31,7 +31,7 @@ inline bool Image::equals(const Image& other) const {
         && (multisampled == other.multisampled);
 }
 
-inline void Image::dump_debug(const std::string& indent) const {
+inline void Texture::dump_debug(const std::string& indent) const {
     const std::string indent2 = indent + "  ";
     fmt::print(stderr, "{}-\n", indent);
     fmt::print(stderr, "{}stage: {}\n", indent2, ShaderStage::to_str(stage));

--- a/src/shdc/types/reflection/texture_sampler.h
+++ b/src/shdc/types/reflection/texture_sampler.h
@@ -5,33 +5,33 @@
 
 namespace shdc::refl {
 
-// special combined-image-samplers for GLSL output with GL semantics
-struct ImageSampler {
+// special combined-texture-samplers for GLSL output with GL semantics
+struct TextureSampler {
     ShaderStage::Enum stage = ShaderStage::Invalid;
     int sokol_slot = -1;
     std::string name;
-    std::string image_name;
+    std::string texture_name;
     std::string sampler_name;
 
-    bool equals(const ImageSampler& other) const;
+    bool equals(const TextureSampler& other) const;
     void dump_debug(const std::string& indent) const;
 };
 
-inline bool ImageSampler::equals(const ImageSampler& other) const {
+inline bool TextureSampler::equals(const TextureSampler& other) const {
     return (stage == other.stage)
         && (sokol_slot == other.sokol_slot)
         && (name == other.name)
-        && (image_name == other.image_name)
+        && (texture_name == other.texture_name)
         && (sampler_name == other.sampler_name);
 }
 
-inline void ImageSampler::dump_debug(const std::string& indent) const {
+inline void TextureSampler::dump_debug(const std::string& indent) const {
     const std::string indent2 = indent + "  ";
     fmt::print(stderr, "{}-\n", indent);
     fmt::print(stderr, "{}stage: {}\n", indent2, ShaderStage::to_str(stage));
     fmt::print(stderr, "{}sokol_slot: {}\n", indent2, sokol_slot);
     fmt::print(stderr, "{}name: {}\n", indent2, name);
-    fmt::print(stderr, "{}image_name: {}\n", indent2, image_name);
+    fmt::print(stderr, "{}texture_name: {}\n", indent2, texture_name);
     fmt::print(stderr, "{}sampler_name: {}\n", indent2, sampler_name);
 }
 


### PR DESCRIPTION
See: https://github.com/floooh/sokol/pull/1287

- [ ] generators:
    - [x] sokol-c
    - [ ] sokol-c3
    - [ ] sokol-d
    - [ ] sokol-jai
    - [ ] sokol-nim
    - [ ] sokol-odin
    - [ ] sokol-rust
    - [ ] sokol-zig
    - [ ] yaml