### PR TITLE
Update for sokol-gfx flexible resource limits.

### DIFF
--- a/src/shdc/types/bind_slot_map.h
+++ b/src/shdc/types/bind_slot_map.h
@@ -182,8 +182,11 @@ inline void BindSlotMap::allocate_backend_slots(ShaderStage::Enum stage) {
                     slot.hlsl.register_u_n = hlsl_register_u_n++;
                 }
                 slot.msl.buffer_n = msl_buffer_n++;
-                // FIXME: must be < MaxStorageBufferBindingsPerStage!
-                // FIXME: this is a problem on min-spec GL drivers with only 8 storage buffer bindslots!
+                // NOTE: use the view bindslot directly here instead of allocating,
+                // since GL has a common storage buffer bindspace for all shader stages.
+                // To avoid problems with minspec GL drivers which only have 8 storage buffer
+                // bindslots in total it's best to put the bindslots for storage buffers in
+                // front of other resource bindings when authoring shaders.
                 slot.glsl.binding_n = i;
                 break;
             case BindSlot::Type::StorageImage:
@@ -224,4 +227,3 @@ inline void BindSlotMap::dump_debug() const {
 }
 
 } // namespace shdc
-

--- a/src/shdc/types/consts.h
+++ b/src/shdc/types/consts.h
@@ -3,21 +3,13 @@
 namespace shdc {
 
 // keep these in sync with:
-//  - SG_MAX_VIEW_BINDSLOTS
 //  - SG_MAX_UNIFORMBLOCKS
-//  - SG_MAX_TEXTURE_BINDINGS_PER_STAGE
-//  - SG_MAX_STORAGEBUFFER_BINDINGS_PER_STAGE
-//  - SG_MAX_STORAGEIMAGE_BINDINGS_PER_STAGE
+//  - SG_MAX_VIEW_BINDSLOTS
 //  - SG_MAX_SAMPLER_BINDSLOTS
-//  - SG_MAX_TEXTURE_SAMPLERS_PAIRS
 //
 inline static const int MaxUniformBlocks = 8;
-inline static const int MaxSamplers = 16;
-inline static const int MaxTextureBindingsPerStage = 16;
-inline static const int MaxStorageBufferBindingsPerStage = 8;
-inline static const int MaxStorageImageBindingsPerStage = 4;
-inline static const int MaxViews = 28;
-inline static const int MaxTextureSamplers = 16;
-static_assert(MaxViews == MaxTextureBindingsPerStage + MaxStorageBufferBindingsPerStage + MaxStorageImageBindingsPerStage);
+inline static const int MaxViews = 32;
+inline static const int MaxSamplers = 12;
+inline static const int MaxTextureSamplers = MaxViews;
 
 } // namespace shdc


### PR DESCRIPTION
No actual code changes needed, only changing the `MaxViews` and `MaxSamplers` constants (increase MaxViews from 28 to 32, and reduce MaxSamplers from 16 to 12). Also code cleanup (remove unused per-stage constants) and update the documentation.