### PR TITLE
yaml: output attr name for reflection

### DIFF
--- a/src/shdc/generators/yaml.cc
+++ b/src/shdc/generators/yaml.cc
@@ -65,7 +65,7 @@ ErrMsg YamlGenerator::generate(const GenInput& gen) {
                     l_open("attrs:\n");
                     for (const auto& attr: prog.vs().inputs) {
                         if (attr.slot >= 0) {
-                            gen_attr(attr, slang);
+                            gen_attr(gen, attr, slang);
                         }
                     }
                     l_close();
@@ -124,11 +124,14 @@ ErrMsg YamlGenerator::generate(const GenInput& gen) {
     return ErrMsg();
 }
 
-void YamlGenerator::gen_attr(const StageAttr& attr, Slang::Enum slang) {
+void YamlGenerator::gen_attr(const GenInput& gen, const StageAttr& attr, Slang::Enum slang) {
     l_open("-\n");
     l("slot: {}\n", attr.slot);
     l("type: {}\n", uniform_type(attr.type_info.type));
     l("base_type: {}\n", attr_basetype(attr.type_info.basetype()));
+    if (gen.args.reflection) {
+        l("name: {}\n", attr.name);
+    }
     if (Slang::is_glsl(slang)) {
         l("glsl_name: {}\n", attr.name);
     } else if (Slang::is_hlsl(slang)) {

--- a/src/shdc/generators/yaml.h
+++ b/src/shdc/generators/yaml.h
@@ -16,7 +16,7 @@ protected:
     virtual std::string sampler_type(refl::SamplerType::Enum e);
     virtual std::string storage_pixel_format(refl::StoragePixelFormat::Enum e);
 private:
-    void gen_attr(const refl::StageAttr& attr, Slang::Enum slang);
+    void gen_attr(const GenInput& gen, const refl::StageAttr& attr, Slang::Enum slang);
     void gen_uniform_block(const GenInput& gen, const refl::UniformBlock& ub, Slang::Enum slang);
     void gen_uniform_block_refl(const refl::UniformBlock& ub);
     void gen_storage_buffer(const refl::StorageBuffer& sbuf, Slang::Enum slang);


### PR DESCRIPTION
The bare yaml output currently lacks attr names, so currently the only reasonable way to get them with the `bare_yaml` output is to parse the shader file. I've put it behind --reflection, since uniform block information is also gated behind it