### PR TITLE
Update odin shader_desc generator proc signature to `c` calling convention

### DIFF
--- a/src/shdc/generators/sokolodin.cc
+++ b/src/shdc/generators/sokolodin.cc
@@ -196,7 +196,7 @@ void SokolOdinGenerator::gen_storage_buffer_decl(const GenInput& gen, const Type
 }
 
 void SokolOdinGenerator::gen_shader_desc_func(const GenInput& gen, const ProgramReflection& prog) {
-    l_open("{}_shader_desc :: proc (backend: sg.Backend) -> sg.Shader_Desc {{\n", prog.name);
+    l_open("{}_shader_desc :: proc \"c\" (backend: sg.Backend) -> sg.Shader_Desc {{\n", prog.name);
     l("desc: sg.Shader_Desc\n");
     l("desc.label = \"{}_shader\"\n", prog.name);
     l("#partial switch backend {{\n");


### PR DESCRIPTION
updates the `*_shader_desc()` proc to the `c` calling convention, allowing it to be called in contextless namespaces

this matches other sokol-app callbacks which are contextless by necessity, allowing shader descriptions to be generated within those callbacks without creating an odin context.

the generated proc body is, as far as I can tell, all assignments to the `desc` struct, so this should not break anything as-is.

however, any future changes that add invocations to non-`contextless` procs within the `*_shader_desc()` proc will introduce bugs in the generated code.