### PR TITLE
Fix unused resources reflection discrepancy between glslang and spirvcross.

### DIFF
--- a/src/shdc/spirv.cc
+++ b/src/shdc/spirv.cc
@@ -71,9 +71,6 @@ static MergedSource merge_source(const Input& inp, const Snippet& snippet, Slang
     ("for (;;) { }") to WebGL
 */
 static void spirv_optimize(Slang::Enum slang, std::vector<uint32_t>& spirv) {
-    if (slang == Slang::WGSL) {
-        return;
-    }
     spv_target_env target_env;
     target_env = SPV_ENV_UNIVERSAL_1_2;
     spvtools::Optimizer optimizer(target_env);

--- a/test/issue213_unused_ub.glsl
+++ b/test/issue213_unused_ub.glsl
@@ -1,0 +1,12 @@
+@vs vs
+layout(binding=0) uniform vs_params {
+    float unused;
+};
+void main() {}
+@end
+
+@fs fs
+void main() {}
+@end
+
+@program shader vs fs


### PR DESCRIPTION
See #213 

Unused resources should be consistently ignored in reflection.

- [x] changelog (also mention in sokol changelog)
- [x] deploy
- [x] update sokol-zig dep
- [x] update sokol-samples webpage