### PR TITLE
Add case for SOKOL_VULKAN when using --ifdef

### DIFF
--- a/docs/sokol-shdc.md
+++ b/docs/sokol-shdc.md
@@ -388,6 +388,7 @@ code into **#ifdef/#endif** pairs using the sokol-gfx backend-selection defines:
     - SOKOL_D3D11
     - SOKOL_METAL
     - SOKOL_WGPU
+    - SOKOL_VULKAN
 - **-d --dump**: Enable verbose debug output, this basically dumps all internal
 information to stdout. Useful for debugging and understanding how sokol-shdc
 works, but not much else :)

--- a/src/shdc/generators/sokolc.cc
+++ b/src/shdc/generators/sokolc.cc
@@ -27,6 +27,8 @@ static const char* sokol_define(Slang::Enum slang) {
             return "SOKOL_METAL";
         case Slang::WGSL:
             return "SOKOL_WGPU";
+        case Slang::SPIRV_VK:
+            return "SOKOL_VULKAN";
         default:
             return "<INVALID>";
     }


### PR DESCRIPTION
Hi, I found that using --ifdef when compiling to spirv results in a header with `#ifdef <INVALID>` in it. I added that case in to the C generator and readme, and it's been working on my end

Thanks for the tool!